### PR TITLE
Add sidebar with session management

### DIFF
--- a/packages/web/src/client/app.ts
+++ b/packages/web/src/client/app.ts
@@ -6,15 +6,20 @@
 import { html, LitElement } from "lit";
 import { customElement, state as litState } from "lit/decorators.js";
 import "@mariozechner/mini-lit/dist/ThemeToggle.js";
+import "@mariozechner/mini-lit/dist/Sidebar.js";
 import type { Chat } from "./components/chat.ts";
 import { state } from "./state.ts";
+import type { Session } from "./types.ts";
 import { WsClient } from "./ws-client.ts";
 import "./components/chat.ts";
+import "./components/sidebar.ts";
 
 @customElement("lil-app")
 export class App extends LitElement {
 	@litState() private wsClient?: WsClient;
 	@litState() private connected = false;
+	@litState() private sessions: Session[] = [];
+	@litState() private currentSessionId: string | null = null;
 
 	private unsubscribe?: () => void;
 
@@ -29,24 +34,32 @@ export class App extends LitElement {
 		this.wsClient = new WsClient();
 		this.wsClient.connect();
 
-		// Subscribe to connection state
+		// Subscribe to state changes
 		this.unsubscribe = state.subscribe(() => {
 			this.connected = state.connected;
+			this.sessions = state.sessions;
+			this.currentSessionId = state.currentSessionId;
 		});
 
-		// Handle WebSocket messages to update connection state
+		// Handle WebSocket messages
 		this.wsClient.subscribe((message) => {
 			if (message.type === "ready") {
 				state.setConnected(true);
 				// Store available sessions
-				const sessions = message.sessions.map((name) => ({ id: name, title: name }));
+				const sessions = message.sessions.map((name) => ({ id: name }));
 				state.setSessions(sessions);
 				state.setCurrentSession(message.sessionName);
+			} else if (message.type === "response" && (message as { sessions?: string[] }).sessions) {
+				// Response from session.list command
+				const sessions = ((message as { sessions?: string[] }).sessions || []).map((name) => ({ id: name }));
+				state.setSessions(sessions);
 			}
 		});
 
-		// Set initial connection state
+		// Set initial state
 		this.connected = state.connected;
+		this.sessions = state.sessions;
+		this.currentSessionId = state.currentSessionId;
 	}
 
 	disconnectedCallback() {
@@ -63,44 +76,47 @@ export class App extends LitElement {
 		}
 	}
 
+	private handleSessionNew() {
+		if (!this.wsClient) return;
+		this.wsClient.send({ type: "session.new" });
+	}
+
+	private handleSessionSwitch(e: CustomEvent) {
+		if (!this.wsClient) return;
+		const { sessionId } = e.detail as { sessionId: string };
+		this.wsClient.send({ type: "session.switch", name: sessionId });
+	}
+
 	render() {
 		return html`
-			<!-- Header -->
-			<div
-				class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-between"
-			>
-				<div class="flex items-center gap-4">
-					<h1 class="text-xl font-bold text-gray-900 dark:text-white">lil</h1>
-				</div>
+			<!-- Sidebar -->
+			<lil-sidebar
+				.sessions=${this.sessions}
+				.currentSessionId=${this.currentSessionId}
+				.connected=${this.connected}
+				@session-new=${this.handleSessionNew}
+				@session-switch=${this.handleSessionSwitch}
+			></lil-sidebar>
 
-				<div class="flex items-center gap-3">
-					${
-						this.connected
-							? html`<span class="text-xs text-green-600 dark:text-green-400">● Connected</span>`
-							: html`<span class="text-xs text-red-600 dark:text-red-400">● Disconnected</span>`
-					}
-
-					<theme-toggle></theme-toggle>
-				</div>
-			</div>
-
-			<!-- Chat area -->
-			${
-				this.connected
-					? html` <lil-chat class="flex-1 min-h-0"></lil-chat> `
-					: html`
-						<div class="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900">
-							<div class="text-center space-y-4">
-								<div class="text-xl font-semibold text-gray-600 dark:text-gray-400">
-									Connecting to server...
-								</div>
-								<div class="text-sm text-gray-500 dark:text-gray-500">
-									Make sure the lil daemon is running
+			<!-- Main content area with left margin for sidebar -->
+			<div class="md:ml-64 min-h-screen flex flex-col">
+				${
+					this.connected
+						? html` <lil-chat class="flex-1"></lil-chat> `
+						: html`
+							<div class="flex-1 flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+								<div class="text-center space-y-4">
+									<div class="text-xl font-semibold text-gray-600 dark:text-gray-400">
+										Connecting to server...
+									</div>
+									<div class="text-sm text-gray-500 dark:text-gray-500">
+										Make sure the lil daemon is running
+									</div>
 								</div>
 							</div>
-						</div>
-					`
-			}
+						`
+				}
+			</div>
 		`;
 	}
 }

--- a/packages/web/src/client/components/message-input.ts
+++ b/packages/web/src/client/components/message-input.ts
@@ -5,8 +5,8 @@
 
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { html, LitElement } from "lit";
-import { customElement, property, state as litState } from "lit/decorators.js";
-import { createRef, ref, type Ref } from "lit/directives/ref.js";
+import { customElement, state as litState, property } from "lit/decorators.js";
+import { createRef, type Ref, ref } from "lit/directives/ref.js";
 import { Paperclip, Send, Square } from "lucide";
 import type { Attachment } from "../types.ts";
 
@@ -107,10 +107,11 @@ export class MessageInput extends LitElement {
 
 	render() {
 		return html`
-			<div class="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4">
+			<div class="p-4">
 				<!-- Attachments preview -->
-				${this.attachments.length > 0
-					? html`
+				${
+					this.attachments.length > 0
+						? html`
 							<div class="mb-2 flex flex-wrap gap-2">
 								${this.attachments.map(
 									(att) => html`
@@ -130,7 +131,8 @@ export class MessageInput extends LitElement {
 								)}
 							</div>
 						`
-					: ""}
+						: ""
+				}
 
 				<!-- Input area -->
 				<div class="flex items-end gap-2">
@@ -163,20 +165,22 @@ export class MessageInput extends LitElement {
 					></textarea>
 
 					<!-- Send/Abort button -->
-					${this.isStreaming
-						? Button({
-								variant: "destructive",
-								size: "icon",
-								onClick: this.handleAbort.bind(this),
-								children: Square({ size: 20 }),
-							})
-						: Button({
-								variant: "primary",
-								size: "icon",
-								disabled: this.disabled || (!this.value.trim() && this.attachments.length === 0),
-								onClick: this.handleSend.bind(this),
-								children: Send({ size: 20 }),
-							})}
+					${
+						this.isStreaming
+							? Button({
+									variant: "destructive",
+									size: "icon",
+									onClick: this.handleAbort.bind(this),
+									children: Square({ size: 20 }),
+								})
+							: Button({
+									variant: "primary",
+									size: "icon",
+									disabled: this.disabled || (!this.value.trim() && this.attachments.length === 0),
+									onClick: this.handleSend.bind(this),
+									children: Send({ size: 20 }),
+								})
+					}
 				</div>
 			</div>
 		`;

--- a/packages/web/src/client/components/sidebar.ts
+++ b/packages/web/src/client/components/sidebar.ts
@@ -1,0 +1,121 @@
+/**
+ * Sidebar component
+ * Session management sidebar with new chat, session list, and footer
+ */
+
+import { Button } from "@mariozechner/mini-lit/dist/Button.js";
+import { icon } from "@mariozechner/mini-lit/dist/icons.js";
+import { SidebarItem, SidebarSection } from "@mariozechner/mini-lit/dist/Sidebar.js";
+import { html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { MessageSquarePlus } from "lucide";
+import type { Session } from "../types.ts";
+
+@customElement("lil-sidebar")
+export class LilSidebar extends LitElement {
+	@property({ type: Array }) sessions: Session[] = [];
+	@property({ type: String }) currentSessionId: string | null = null;
+	@property({ type: Boolean }) connected = false;
+
+	createRenderRoot() {
+		return this; // Use light DOM for Tailwind classes
+	}
+
+	private handleNewChat() {
+		this.dispatchEvent(new CustomEvent("session-new"));
+	}
+
+	private handleSessionClick(sessionId: string) {
+		if (sessionId !== this.currentSessionId) {
+			this.dispatchEvent(
+				new CustomEvent("session-switch", {
+					detail: { sessionId },
+				}),
+			);
+		}
+	}
+
+	private formatSessionName(name: string): string {
+		// Format session names for display
+		// "default" → "Default"
+		// "session-1771755393484" → "Session • Feb 23"
+		if (name === "default") {
+			return "Default";
+		}
+
+		if (name.startsWith("session-")) {
+			const timestamp = Number.parseInt(name.substring(8), 10);
+			if (!Number.isNaN(timestamp)) {
+				const date = new Date(timestamp);
+				const formatted = date.toLocaleDateString("en-US", {
+					month: "short",
+					day: "numeric",
+				});
+				return `Session • ${formatted}`;
+			}
+		}
+
+		// Fallback: just clean up the name
+		return name.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+	}
+
+	render() {
+		// Prepare session items
+		const sessionItems = this.sessions.map((session) =>
+			SidebarItem({
+				active: session.id === this.currentSessionId,
+				onClick: () => this.handleSessionClick(session.id),
+				children: html`
+						<div class="flex items-center gap-2">
+							<span class="flex-1 truncate">${this.formatSessionName(session.id)}</span>
+						</div>
+					`,
+			}),
+		);
+
+		const content = html`
+			<!-- New Chat Button -->
+			<div class="mb-4">
+				${Button({
+					variant: "outline",
+					className: "w-full justify-start gap-2",
+					onClick: this.handleNewChat.bind(this),
+					children: html`
+						${icon(MessageSquarePlus, "sm")}
+						<span>New Chat</span>
+					`,
+				})}
+			</div>
+
+			<!-- Sessions -->
+			${
+				this.sessions.length > 0
+					? SidebarSection({
+							title: "Recent",
+							children: html`${sessionItems}`,
+						})
+					: html`
+						<div class="text-sm text-muted-foreground text-center py-8">
+							No sessions yet. Start a conversation!
+						</div>
+					`
+			}
+		`;
+
+		const footer = html`
+			<div class="flex items-center justify-between">
+				<div class="flex items-center gap-2">
+					<span class="text-xs ${this.connected ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}">
+						● ${this.connected ? "Connected" : "Disconnected"}
+					</span>
+				</div>
+				<theme-toggle></theme-toggle>
+			</div>
+		`;
+
+		return html`
+			<mini-sidebar .content=${content} .logo=${html`<h1 class="text-xl font-bold">lil</h1>`} .footer=${footer}>
+			</mini-sidebar>
+		`;
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #8: Transform the bare chat UI into a Claude/ChatGPT-style interface with a collapsible sidebar for session management.

## Changes

### 🐛 Fix: Message Conversion Bug
**File**: 

The server sends message  as an array of content parts:
```json
{"content": [{"type": "text", "text": "Hello"}]}
```

The client was casting this as a string, causing messages to display as `[object Object]` or be empty.

**Fix**: Properly extract text from content parts array in `convertMessages()`.

### ✨ New: Sidebar Component
**File**: `packages/web/src/client/components/sidebar.ts` (new)

Uses mini-lit's `<mini-sidebar>`, `SidebarItem`, `SidebarSection` to create:
- App logo ("lil")
- New Chat button (with icon)
- Session list with "Recent" section
- Active session highlighting
- Connection status indicator
- Theme toggle
- Fully responsive (hamburger menu on mobile)

Sessions are formatted for display:
- `"default"` → "Default"
- `"session-1771755393484"` → "Session • Feb 23"

### 🎨 Restructure: App Layout
**File**: `packages/web/src/client/app.ts`

Replaced top header bar with sidebar + main content:

```
┌──────────┬────────────────────────────────────┐
│ lil      │                                    │
│ + New    │                                    │
│──────────│         Chat content               │
│ Recents  │         (centered, max-width)      │
│ session1 │                                    │
│ session2 │                                    │
│──────────│                                    │
│ 🌙 ● On  │                                    │
└──────────┴────────────────────────────────────┘
```

- Sidebar on left (collapsible on mobile with `md:ml-64`)
- Handles `session-new` and `session-switch` events
- Wires WebSocket commands (`session.new`, `session.switch`)
- Updates session list from `ready` and `response` messages

### 📐 Layout: Centered Chat Content
**Files**: `packages/web/src/client/components/chat.ts`, `message-input.ts`

- Wrap messages and input in `max-w-3xl mx-auto` container
- Claude/ChatGPT-style centered layout for better readability
- Remove full-width border on input for cleaner appearance

## Bundle Size Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Bundle | 130KB | 137KB | +7KB |
| Gzipped | 41KB | 43KB | +2KB |

Minimal increase for the sidebar component.

## Testing

✅ **Build**: Successful
```
dist/client/assets/index-CmXcLhdh.js   137.39 kB │ gzip: 43.15 kB
✓ built in 689ms
```

✅ **Linting**: Formatted (16 warnings are pre-existing `any` types in server code)

🔄 **Manual Testing Needed**:
- Verify sidebar renders and is collapsible on mobile
- Test session list populates from WebSocket
- Test "New Chat" button creates new session
- Test clicking session switches conversation
- Verify messages now display text correctly
- Verify centered layout looks good

## Screenshots Needed

Please test and add screenshots of:
1. Desktop view with sidebar open
2. Mobile view with hamburger menu
3. Session list with multiple sessions
4. Centered chat layout

## Closes

Closes #8