### PR TITLE
Fix: Always reply in Slack threads instead of channel

### DIFF
--- a/packages/lil/src/daemon.ts
+++ b/packages/lil/src/daemon.ts
@@ -275,7 +275,8 @@ async function processMessage(
 	console.log(`[daemon] ${message.channel}/${message.chatId}${sessionInfo} (${message.senderName}): ${preview}`);
 
 	// Prepare send options for thread-aware responses
-	const sendOptions = message.threadId ? { threadId: message.threadId } : undefined;
+	// Always reply in a thread: use existing thread or create new one with message.id as parent
+	const sendOptions = { threadId: message.threadId || message.id };
 
 	try {
 		const trimmed = message.text.trim();


### PR DESCRIPTION
## Problem

When users @mention the bot in a channel (not already in a thread), the bot was replying directly in the channel. This creates noise and makes it hard to follow conversations.

## Solution

Changed the bot to **always reply in threads**:

- **New @mention in channel** → bot creates a thread using the original message as parent
- **@mention in existing thread** → bot continues the thread

## Code Change

```typescript
// Before
const sendOptions = message.threadId ? { threadId: message.threadId } : undefined;

// After
const sendOptions = { threadId: message.threadId || message.id };
```

## Behavior

### Before
```
Channel: #general
You: @lil what's the weather?
Bot: It's 68°F and sunny [posted directly in channel] ❌
```

### After
```
Channel: #general
You: @lil what's the weather?
  Thread 🧵
  Bot: It's 68°F and sunny ✅
```

## Benefits

✅ Keeps channels clean  
✅ Groups related messages together  
✅ Makes conversations easier to follow  
✅ Matches standard Slack bot UX patterns

## Testing

Manually tested in Slack workspace - bot now creates threads for all responses.