### PR TITLE
Improve Slack adapter: robustness and feature coverage

### DIFF
--- a/packages/clankie/slack-app-manifest.yaml
+++ b/packages/clankie/slack-app-manifest.yaml
@@ -17,7 +17,9 @@ oauth_config:
       - channels:read
       - files:read
       - groups:history
+      - groups:read
       - im:history
+      - mpim:history
 
 settings:
   event_subscriptions:
@@ -26,6 +28,7 @@ settings:
       - message.channels
       - message.groups
       - message.im
+      - message.mpim
   interactivity:
     is_enabled: false
   org_deploy_enabled: false

--- a/packages/clankie/src/channels/slack.ts
+++ b/packages/clankie/src/channels/slack.ts
@@ -5,22 +5,33 @@
  * - Slack app with Socket Mode enabled
  * - App token (xapp-...) for Socket Mode connection
  * - Bot token (xoxb-...) for API calls
- * - Bot scopes: app_mentions:read, chat:write, files:read, im:history, channels:history, channels:read
- * - Event subscriptions: app_mention, message.channels, message.im
+ * - Bot scopes: app_mentions:read, chat:write, files:read, im:history, mpim:history,
+ *   channels:history, channels:read, groups:history, groups:read
+ * - Event subscriptions: app_mention, message.channels, message.groups, message.im, message.mpim
  *
  * Responds to:
- * - @mentions in channels (starts a conversation thread)
+ * - @mentions in channels and private channels (starts a conversation thread)
  * - Messages in threads where bot was @mentioned (continues conversation)
- * - Direct messages
+ * - Direct messages (1:1 and multi-party DMs)
  *
- * Supports file attachments (downloads from Slack, converts to base64).
+ * Features:
+ * - File attachments (downloads from Slack, converts to base64)
+ * - Thread persistence (survives daemon restarts, 7-day TTL)
+ * - Channel allowlisting (optional)
+ * - User allowlisting (required)
+ * - Link unfurling disabled (keeps responses clean)
  */
 
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 import type { Attachment, Channel, InboundMessage, MessageHandler, SendOptions } from "./channel.ts";
 
 const SLACK_MAX_LENGTH = 4000; // Slack's actual limit is ~40k, but chunk conservatively
+const ACTIVE_THREADS_FILE = join(homedir(), ".clankie", "slack-active-threads.json");
+const THREAD_TTL_DAYS = 7; // Threads older than this are cleaned up
 
 export interface SlackChannelOptions {
 	/** App token from Slack app settings (xapp-...) */
@@ -29,6 +40,8 @@ export interface SlackChannelOptions {
 	botToken: string;
 	/** Allowed Slack user IDs. Empty = deny all. */
 	allowedUsers: string[];
+	/** Allowed Slack channel IDs. Empty = allow all. */
+	allowedChannelIds?: string[];
 }
 
 export class SlackChannel implements Channel {
@@ -36,19 +49,29 @@ export class SlackChannel implements Channel {
 	private socketClient: SocketModeClient;
 	private webClient: WebClient;
 	private allowedUsers: Set<string>;
+	private allowedChannelIds: Set<string> | null;
 	private handler: MessageHandler | undefined;
 	private botUserId: string | null = null;
-	/** Threads where bot has been @mentioned - these become active conversations */
-	private activeThreads: Set<string> = new Set();
+	/** Threads where bot has been @mentioned - Map<threadId, timestamp> for TTL cleanup */
+	private activeThreads: Map<string, number> = new Map();
 
 	constructor(private options: SlackChannelOptions) {
-		this.socketClient = new SocketModeClient({ appToken: options.appToken });
+		this.socketClient = new SocketModeClient({
+			appToken: options.appToken,
+			// biome-ignore lint/suspicious/noExplicitAny: Slack SDK logLevel type is not exported
+			logLevel: "ERROR" as any, // Suppress noisy internal logging
+		});
 		this.webClient = new WebClient(options.botToken);
 		this.allowedUsers = new Set(options.allowedUsers);
+		// null = allow all channels; Set = filter by channel ID
+		this.allowedChannelIds = options.allowedChannelIds?.length ? new Set(options.allowedChannelIds) : null;
 	}
 
 	async start(handler: MessageHandler): Promise<void> {
 		this.handler = handler;
+
+		// Load persisted active threads
+		this.loadActiveThreads();
 
 		// Get bot user ID
 		const auth = await this.webClient.auth.test();
@@ -66,6 +89,8 @@ export class SlackChannel implements Channel {
 				channel: chatId,
 				text,
 				thread_ts: options?.threadId,
+				unfurl_links: false,
+				unfurl_media: false,
 			});
 			return;
 		}
@@ -77,6 +102,8 @@ export class SlackChannel implements Channel {
 				channel: chatId,
 				text: chunk,
 				thread_ts: options?.threadId,
+				unfurl_links: false,
+				unfurl_media: false,
 			});
 		}
 	}
@@ -88,113 +115,187 @@ export class SlackChannel implements Channel {
 
 	// ─── Private helpers ──────────────────────────────────────────────────
 
+	/** Check if a channel is allowed (null allowedChannelIds = allow all) */
+	private isChannelAllowed(channelId: string): boolean {
+		return this.allowedChannelIds === null || this.allowedChannelIds.has(channelId);
+	}
+
+	/** Load active threads from disk (with TTL cleanup) */
+	private loadActiveThreads(): void {
+		if (!existsSync(ACTIVE_THREADS_FILE)) return;
+
+		try {
+			const raw = readFileSync(ACTIVE_THREADS_FILE, "utf-8");
+			const data = JSON.parse(raw) as Record<string, number>;
+			const now = Date.now();
+			const ttlMs = THREAD_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+			let loaded = 0;
+			let expired = 0;
+
+			for (const [threadId, timestamp] of Object.entries(data)) {
+				if (now - timestamp > ttlMs) {
+					expired++;
+					continue;
+				}
+				this.activeThreads.set(threadId, timestamp);
+				loaded++;
+			}
+
+			if (loaded > 0) {
+				console.log(`[slack] Loaded ${loaded} active thread(s) from disk${expired > 0 ? ` (${expired} expired)` : ""}`);
+			}
+		} catch (err) {
+			console.warn(`[slack] Failed to load active threads: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	/** Save active threads to disk */
+	private saveActiveThreads(): void {
+		try {
+			const dir = join(homedir(), ".clankie");
+			if (!existsSync(dir)) {
+				mkdirSync(dir, { recursive: true, mode: 0o700 });
+			}
+
+			const data: Record<string, number> = {};
+			for (const [threadId, timestamp] of this.activeThreads.entries()) {
+				data[threadId] = timestamp;
+			}
+
+			writeFileSync(ACTIVE_THREADS_FILE, JSON.stringify(data, null, 2), "utf-8");
+		} catch (err) {
+			console.warn(`[slack] Failed to save active threads: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
 	private setupEventHandlers(): void {
 		// Handle @mentions in channels
 		this.socketClient.on("app_mention", async ({ event, ack }) => {
-			await ack();
+			try {
+				await ack();
 
-			const e = event as {
-				text: string;
-				channel: string;
-				user: string;
-				ts: string;
-				thread_ts?: string;
-				files?: Array<{
-					id: string;
-					name?: string;
-					mimetype?: string;
-					url_private_download?: string;
-				}>;
-			};
+				const e = event as {
+					text: string;
+					channel: string;
+					user: string;
+					ts: string;
+					thread_ts?: string;
+					files?: Array<{
+						id: string;
+						name?: string;
+						mimetype?: string;
+						url_private_download?: string;
+					}>;
+				};
 
-			if (!this.allowedUsers.has(e.user)) {
-				console.log(`[slack] Ignoring mention from unauthorized user: ${e.user}`);
-				return;
+				// Check channel allowlist
+				if (!this.isChannelAllowed(e.channel)) {
+					console.log(`[slack] Ignoring mention in disallowed channel: ${e.channel}`);
+					return;
+				}
+
+				if (!this.allowedUsers.has(e.user)) {
+					console.log(`[slack] Ignoring mention from unauthorized user: ${e.user}`);
+					return;
+				}
+
+				// Track this thread as active for future conversation
+				const threadId = e.thread_ts || e.ts;
+				this.activeThreads.set(threadId, Date.now());
+				this.saveActiveThreads();
+				console.log(`[slack] Thread ${threadId} is now active (${this.activeThreads.size} total)`);
+
+				// Strip bot mention from text
+				const text = e.text.replace(/<@[A-Z0-9]+>/gi, "").trim();
+
+				const message: InboundMessage = {
+					id: e.ts,
+					channel: this.name,
+					senderId: e.user,
+					chatId: e.channel,
+					threadId: e.thread_ts,
+					text,
+					timestamp: parseFloat(e.ts) * 1000,
+				};
+
+				// Download attachments
+				if (e.files && e.files.length > 0) {
+					message.attachments = await this.downloadFiles(e.files);
+				}
+
+				await this.handler?.(message);
+			} catch (err) {
+				console.error("[slack] Error in app_mention handler:", err);
 			}
-
-			// Track this thread as active for future conversation
-			const threadId = e.thread_ts || e.ts;
-			this.activeThreads.add(threadId);
-			console.log(`[slack] Thread ${threadId} is now active (${this.activeThreads.size} total)`);
-
-			// Strip bot mention from text
-			const text = e.text.replace(/<@[A-Z0-9]+>/gi, "").trim();
-
-			const message: InboundMessage = {
-				id: e.ts,
-				channel: this.name,
-				senderId: e.user,
-				chatId: e.channel,
-				threadId: e.thread_ts,
-				text,
-				timestamp: parseFloat(e.ts) * 1000,
-			};
-
-			// Download attachments
-			if (e.files && e.files.length > 0) {
-				message.attachments = await this.downloadFiles(e.files);
-			}
-
-			await this.handler?.(message);
 		});
 
 		// Handle direct messages and thread replies
 		this.socketClient.on("message", async ({ event, ack }) => {
-			await ack();
+			try {
+				await ack();
 
-			const e = event as {
-				text?: string;
-				channel: string;
-				user?: string;
-				ts: string;
-				channel_type?: string;
-				subtype?: string;
-				bot_id?: string;
-				thread_ts?: string;
-				files?: Array<{
-					id: string;
-					name?: string;
-					mimetype?: string;
-					url_private_download?: string;
-				}>;
-			};
+				const e = event as {
+					text?: string;
+					channel: string;
+					user?: string;
+					ts: string;
+					channel_type?: string;
+					subtype?: string;
+					bot_id?: string;
+					thread_ts?: string;
+					files?: Array<{
+						id: string;
+						name?: string;
+						mimetype?: string;
+						url_private_download?: string;
+					}>;
+				};
 
-			// Skip bot messages, message edits, etc.
-			if (e.bot_id || !e.user || e.user === this.botUserId) return;
-			if (e.subtype !== undefined && e.subtype !== "file_share") return;
-			if (!e.text && (!e.files || e.files.length === 0)) return;
+				// Skip bot messages, message edits, etc.
+				if (e.bot_id || !e.user || e.user === this.botUserId) return;
+				if (e.subtype !== undefined && e.subtype !== "file_share") return;
+				if (!e.text && (!e.files || e.files.length === 0)) return;
 
-			const isDM = e.channel_type === "im";
-			const isBotMention = e.text?.includes(`<@${this.botUserId}>`);
-			const isInActiveThread = e.thread_ts && this.activeThreads.has(e.thread_ts);
+				// Check channel allowlist
+				if (!this.isChannelAllowed(e.channel)) return;
 
-			// Skip channel @mentions (handled by app_mention event)
-			if (!isDM && isBotMention) return;
+				const isDM = e.channel_type === "im";
+				const isMpim = e.channel_type === "mpim"; // Multi-party DM
+				const isBotMention = e.text?.includes(`<@${this.botUserId}>`);
+				const isInActiveThread = e.thread_ts && this.activeThreads.has(e.thread_ts);
 
-			// Only process: DMs OR messages in active threads
-			if (!isDM && !isInActiveThread) return;
+				// Skip channel/group @mentions (handled by app_mention event)
+				// Note: mpim (multi-party DMs) don't fire app_mention, so we must NOT skip those
+				if (!isDM && !isMpim && isBotMention) return;
 
-			if (!this.allowedUsers.has(e.user)) {
-				console.log(`[slack] Ignoring message from unauthorized user: ${e.user}`);
-				return;
+				// Only process: DMs, multi-party DMs, OR messages in active threads
+				if (!isDM && !isMpim && !isInActiveThread) return;
+
+				if (!this.allowedUsers.has(e.user)) {
+					console.log(`[slack] Ignoring message from unauthorized user: ${e.user}`);
+					return;
+				}
+
+				const message: InboundMessage = {
+					id: e.ts,
+					channel: this.name,
+					senderId: e.user,
+					chatId: e.channel,
+					threadId: e.thread_ts,
+					text: e.text || "",
+					timestamp: parseFloat(e.ts) * 1000,
+				};
+
+				// Download attachments
+				if (e.files && e.files.length > 0) {
+					message.attachments = await this.downloadFiles(e.files);
+				}
+
+				await this.handler?.(message);
+			} catch (err) {
+				console.error("[slack] Error in message handler:", err);
 			}
-
-			const message: InboundMessage = {
-				id: e.ts,
-				channel: this.name,
-				senderId: e.user,
-				chatId: e.channel,
-				threadId: e.thread_ts,
-				text: e.text || "",
-				timestamp: parseFloat(e.ts) * 1000,
-			};
-
-			// Download attachments
-			if (e.files && e.files.length > 0) {
-				message.attachments = await this.downloadFiles(e.files);
-			}
-
-			await this.handler?.(message);
 		});
 	}
 

--- a/packages/clankie/src/config.ts
+++ b/packages/clankie/src/config.ts
@@ -47,6 +47,8 @@ export interface AppConfig {
 			botToken?: string;
 			/** Allowed Slack user IDs */
 			allowFrom?: string[];
+			/** Allowed Slack channel IDs (empty = allow all) */
+			allowedChannelIds?: string[];
 		};
 	};
 

--- a/packages/clankie/src/daemon.ts
+++ b/packages/clankie/src/daemon.ts
@@ -601,6 +601,7 @@ export async function startDaemon(): Promise<void> {
 				appToken: slack.appToken,
 				botToken: slack.botToken,
 				allowedUsers: slack.allowFrom ?? [],
+				allowedChannelIds: slack.allowedChannelIds,
 			}),
 		);
 	}


### PR DESCRIPTION
## Summary

Implements improvements from #25 to make the Slack adapter more robust and feature-complete.

## Changes

### High Priority ✅
- **Unfurl control** — Added  and  to outgoing messages to prevent noisy link previews
- **Error handling** — Wrapped both event handlers (, ) in try/catch blocks for resilience
- **Channel type support** — Added proper handling for private channels () and multi-party DMs ()
- **Log level** — Suppressed noisy Socket Mode internal logging with `logLevel: "ERROR"`

### Medium Priority ✅
- **Channel allowlisting** — Added optional `allowedChannelIds` config (empty = allow all)
- **Thread persistence** — Active threads now persist to `~/.clankie/slack-active-threads.json` with 7-day TTL, so thread replies work across daemon restarts

### Updated Files
- `packages/clankie/src/channels/slack.ts` — All improvements, updated docstring
- `packages/clankie/src/config.ts` — Added `allowedChannelIds` to Slack config type
- `packages/clankie/src/daemon.ts` — Wire `allowedChannelIds` through to constructor
- `packages/clankie/slack-app-manifest.yaml` — Added `groups:read`, `mpim:history` scopes and `message.mpim` event

## Testing

- ✅ `bun run check` passes (format + lint)
- Thread persistence tested: load/save logic with TTL cleanup
- Channel/user allowlisting logic validated

## Migration

**For existing users:** Active threads from before this update won't be persisted (in-memory state is lost). After restart, users must @mention the bot again in those threads to reactivate them. Future thread state will persist automatically.

**Config update (optional):** Add channel allowlisting to `~/.clankie/clankie.json`:
```json
{
  "channels": {
    "slack": {
      "allowedChannelIds": ["C0123456789", "C9876543210"]
    }
  }
}
```

**Slack app update:** Reinstall the bot with the updated manifest to get new scopes (`groups:read`, `mpim:history`) and `message.mpim` event subscription.

Fixes #25