### PR TITLE
fix: update repository URL from lil to clankie

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ bun --version
 ### 2. Clone and Install
 
 ```bash
-git clone https://github.com/thiagovarela/lil
-cd lil
+git clone https://github.com/thiagovarela/clankie
+cd clankie
 bun install
 ```
 


### PR DESCRIPTION
## Changes

Update installation instructions to use the canonical repository URL.

**Before:**
```bash
git clone https://github.com/thiagovarela/lil
cd lil
```

**After:**
```bash
git clone https://github.com/thiagovarela/clankie
cd clankie
```

The old URL still works (GitHub redirects), but the canonical name is clearer for new users.