### PR TITLE
feat(web-ui): Add session sidebar with multi-session support

### DIFF
--- a/web-ui/src/components/session-sidebar.tsx
+++ b/web-ui/src/components/session-sidebar.tsx
@@ -1,0 +1,87 @@
+import { useStore } from '@tanstack/react-store'
+import { MessageSquare, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { sessionsListStore } from '@/stores/sessions-list'
+import { clientManager } from '@/lib/client-manager'
+import { cn } from '@/lib/utils'
+
+export function SessionSidebar() {
+  const { sessions, activeSessionId } = useStore(
+    sessionsListStore,
+    (state) => ({
+      sessions: state.sessions,
+      activeSessionId: state.activeSessionId,
+    }),
+  )
+
+  const handleNewChat = async () => {
+    await clientManager.createNewSession()
+  }
+
+  const handleSelectSession = (sessionId: string) => {
+    if (sessionId === activeSessionId) return
+    clientManager.switchSession(sessionId)
+  }
+
+  return (
+    <div className="flex h-full w-64 flex-col border-r border-sidebar-border bg-sidebar">
+      <div className="p-4">
+        <Button onClick={handleNewChat} className="w-full" size="sm">
+          <Plus className="mr-2 h-4 w-4" />
+          New Chat
+        </Button>
+      </div>
+
+      <Separator />
+
+      <div className="flex-1 overflow-y-auto p-2">
+        {sessions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-32 text-center p-4">
+            <MessageSquare className="h-8 w-8 text-sidebar-foreground/50 mb-2" />
+            <p className="text-sm text-sidebar-foreground/70">
+              No sessions yet
+            </p>
+            <p className="text-xs text-sidebar-foreground/50">
+              Click "New Chat" to start
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {sessions.map((session) => (
+              <button
+                key={session.sessionId}
+                onClick={() => handleSelectSession(session.sessionId)}
+                className={cn(
+                  'w-full rounded-md p-3 text-left transition-colors',
+                  'hover:bg-sidebar-accent',
+                  session.sessionId === activeSessionId
+                    ? 'bg-sidebar-accent'
+                    : 'bg-transparent',
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-sidebar-foreground truncate">
+                      {session.name || 'New chat'}
+                    </p>
+                    {session.model && (
+                      <p className="text-xs text-sidebar-foreground/60 truncate">
+                        {session.model.name}
+                      </p>
+                    )}
+                  </div>
+                  {session.messageCount > 0 && (
+                    <span className="text-xs text-sidebar-foreground/50 shrink-0">
+                      {session.messageCount}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -66,6 +66,15 @@ export class ClankieClient {
 		return response as { sessionId: string; cancelled: boolean };
 	}
 
+	async listSessions(): Promise<{
+		sessions: Array<{ sessionId: string; name?: string; model?: ModelInfo; messageCount: number }>;
+	}> {
+		const response = await this.sendCommand({ type: "list_sessions" });
+		return response as {
+			sessions: Array<{ sessionId: string; name?: string; model?: ModelInfo; messageCount: number }>;
+		};
+	}
+
 	async prompt(sessionId: string, message: string): Promise<void> {
 		await this.sendCommand({ type: "prompt", message }, sessionId);
 	}

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -19,6 +19,7 @@ export type RpcCommand =
 	| { id?: string; type: "follow_up"; message: string; images?: ImageContent[] }
 	| { id?: string; type: "abort" }
 	| { id?: string; type: "new_session"; parentSession?: string }
+	| { id?: string; type: "list_sessions" }
 	| { id?: string; type: "get_state" }
 	| { id?: string; type: "set_model"; provider: string; modelId: string }
 	| { id?: string; type: "cycle_model" }

--- a/web-ui/src/stores/sessions-list.ts
+++ b/web-ui/src/stores/sessions-list.ts
@@ -1,0 +1,76 @@
+/**
+ * Sessions list store — manages the list of all available sessions
+ * and tracks which one is currently active.
+ */
+
+import { Store } from '@tanstack/store'
+import type { ModelInfo } from '@/lib/types'
+
+export interface SessionListItem {
+  sessionId: string
+  name?: string
+  model?: ModelInfo
+  messageCount: number
+  createdAt: number
+}
+
+export interface SessionsListStore {
+  sessions: Array<SessionListItem>
+  activeSessionId: string | null
+}
+
+const INITIAL_STATE: SessionsListStore = {
+  sessions: [],
+  activeSessionId: null,
+}
+
+export const sessionsListStore = new Store<SessionsListStore>(INITIAL_STATE)
+
+// ─── Actions ───────────────────────────────────────────────────────────────────
+
+export function addSession(session: SessionListItem): void {
+  sessionsListStore.setState((state) => {
+    // Don't add duplicates
+    if (state.sessions.some((s) => s.sessionId === session.sessionId)) {
+      return state
+    }
+
+    return {
+      ...state,
+      sessions: [...state.sessions, session],
+    }
+  })
+}
+
+export function removeSession(sessionId: string): void {
+  sessionsListStore.setState((state) => ({
+    ...state,
+    sessions: state.sessions.filter((s) => s.sessionId !== sessionId),
+    // Clear active if removing active session
+    activeSessionId:
+      state.activeSessionId === sessionId ? null : state.activeSessionId,
+  }))
+}
+
+export function setActiveSession(sessionId: string): void {
+  sessionsListStore.setState((state) => ({
+    ...state,
+    activeSessionId: sessionId,
+  }))
+}
+
+export function updateSessionMeta(
+  sessionId: string,
+  updates: Partial<Omit<SessionListItem, 'sessionId' | 'createdAt'>>,
+): void {
+  sessionsListStore.setState((state) => ({
+    ...state,
+    sessions: state.sessions.map((s) =>
+      s.sessionId === sessionId ? { ...s, ...updates } : s,
+    ),
+  }))
+}
+
+export function clearSessions(): void {
+  sessionsListStore.setState(INITIAL_STATE)
+}


### PR DESCRIPTION
## Summary

Implements session management in the web UI with a sidebar that lists all active sessions and allows switching between them.

Closes #40

## Changes

### Backend (`src/channels/web.ts`)
- ✅ Added `list_sessions` RPC command to query active sessions with metadata

### Frontend - Core
**New files:**
- `web-ui/src/stores/sessions-list.ts` - Store for tracking all sessions and active session
- `web-ui/src/components/session-sidebar.tsx` - Sidebar UI component

**Modified files:**
- `web-ui/src/lib/types.ts` - Added `list_sessions` RPC command type
- `web-ui/src/lib/clankie-client.ts` - Added `listSessions()` method
- `web-ui/src/lib/client-manager.ts` - **Major refactor** for multi-session support:
  - Filter events by active session before updating UI stores
  - Update session metadata in sessions-list for all sessions
  - Added `createNewSession()` method
  - Added `switchSession(sessionId)` method with message/state loading
  - Clear sessions on disconnect
- `web-ui/src/routes/index.tsx` - Integrated SessionSidebar into layout

## Features

- ✅ **Session list sidebar** with:
  - "New Chat" button to create sessions
  - Session name (or "New chat" placeholder)
  - Model name and message count
  - Active session highlighting
  - Click to switch sessions
- ✅ **Multi-session event routing**: Events for non-active sessions update metadata only, not the UI
- ✅ **Session switching**: Clears messages, fetches historical messages and state for target session
- ✅ **Auto-create first session** on connect

## Architecture

The key insight is that the backend already supported multiple sessions per WebSocket connection. The frontend now:

1. Tracks all sessions in `sessions-list` store
2. Routes incoming events:
   - Metadata updates (name, model, message count) → update sessions-list for any session
   - UI updates (streaming, messages) → only for active session
3. Session switching = update active ID + fetch messages/state

## Testing

- ✅ TypeScript build passes
- ✅ Clean merge with main (no conflicts)
- ✅ Manual testing recommended: create multiple sessions, switch between them, verify messages persist

## Follow-up work

- Session persistence across page refresh (localStorage + resume RPC)
- Session deletion
- Inline session rename
- Collapsible sidebar
- Mobile responsive layout