### PR TITLE
fix(web-ui): Fix session creation race condition and flickering

### DIFF
--- a/web-ui/src/components/chat-input.tsx
+++ b/web-ui/src/components/chat-input.tsx
@@ -52,6 +52,8 @@ export function ChatInput() {
 			<div className="flex gap-2">
 				<Textarea
 					ref={textareaRef}
+					id="chat-input"
+					name="message"
 					value={message}
 					onChange={(e) => setMessage(e.target.value)}
 					onKeyDown={handleKeyDown}

--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -271,7 +271,16 @@ class ClientManager {
 				return null;
 			}
 
-			// Session will be added to the list via session_start event
+			// Optimistically add session to the list immediately
+			// (session_start event will update metadata later)
+			addSession({
+				sessionId: result.sessionId,
+				name: undefined,
+				model: undefined,
+				messageCount: 0,
+				createdAt: Date.now(),
+			});
+
 			// Set it as active
 			setActiveSession(result.sessionId);
 

--- a/web-ui/src/routes/index.tsx
+++ b/web-ui/src/routes/index.tsx
@@ -31,10 +31,12 @@ function ChatPage() {
 	// Auto-create first session when connected
 	useEffect(() => {
 		if (isConnected && sessions.length === 0 && !isCreatingSession) {
+			console.log("[ChatPage] Auto-creating first session");
 			setIsCreatingSession(true);
 			clientManager
 				.createNewSession()
-				.then(() => {
+				.then((sessionId) => {
+					console.log("[ChatPage] Session created:", sessionId);
 					setIsCreatingSession(false);
 				})
 				.catch((err) => {
@@ -63,7 +65,7 @@ function ChatPage() {
 		);
 	}
 
-	if (isCreatingSession) {
+	if (isCreatingSession && sessions.length === 0) {
 		return (
 			<div className="flex h-full items-center justify-center">
 				<div className="text-center space-y-2">


### PR DESCRIPTION
## Problem

Two issues reported after merging the session sidebar feature:

1. **Sessions not loading / infinite flickering**
   - Symptom: Loading spinner appears/disappears repeatedly
   - Root cause: Race condition in session creation

2. **Form field warnings in console**
   - `Node cannot be found in the current page`
   - `A form field element has neither an id nor a name attribute`

## Root Cause Analysis

### Race Condition Flow

**Before fix:**
1. `useEffect` sees `isConnected=true`, `sessions.length=0` → calls `createNewSession()`
2. `createNewSession()` sends RPC → server responds with sessionId
3. RPC promise resolves, returns sessionId
4. **At this point, `sessions` list is still empty!** (session_start event hasn't arrived yet)
5. `setIsCreatingSession(false)` triggers re-render
6. `useEffect` runs again, sees `sessions.length=0` → creates another session!
7. Repeat infinitely ♾️

**Why it happened:**
- WebSocket events (session_start) are async
- They can arrive **after** the RPC promise resolves
- `useEffect` dependency on `sessions.length` caused immediate re-trigger

## Solution

### 1. Optimistic Session Addition
```ts
async createNewSession(): Promise<string | null> {
  const result = await this.client.newSession();
  
  // ✅ Immediately add to list (optimistic)
  addSession({
    sessionId: result.sessionId,
    messageCount: 0,
    createdAt: Date.now(),
  });
  
  // session_start event will update metadata later
}
```

**Benefits:**
- `sessions.length` is non-zero immediately after RPC resolves
- `useEffect` won't re-trigger
- `addSession()` has duplicate checking, so session_start event is safe

### 2. Fix Loading Screen Flicker
```ts
// Before: Shows loading even when session exists
if (isCreatingSession) { ... }

// After: Only show when truly waiting
if (isCreatingSession && sessions.length === 0) { ... }
```

Handles case where session_start arrives before promise resolves.

### 3. Add Form Field Attributes
```tsx
<Textarea
  id="chat-input"
  name="message"
  // ...
/>
```

Fixes accessibility warnings.

## Testing

✅ Build passes  
✅ TypeScript checks pass  
🧪 Manual test needed: Connect → verify single session created (not multiple)

## Files Changed

- `web-ui/src/lib/client-manager.ts` — Optimistic session add
- `web-ui/src/routes/index.tsx` — Fix loading screen logic + debug logging
- `web-ui/src/components/chat-input.tsx` — Add id/name to textarea