### PR TITLE
feat: add mise task to build and release web-ui to GitHub Releases

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -35,3 +35,44 @@ git push && git push --tags
 
 echo "✓ Published $NEW_VERSION"
 """
+
+[tasks.release-web-ui]
+description = "Build web-ui and publish to GitHub Releases"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-$(node -p "require('./package.json').version")}"
+TAG="web-ui-v${VERSION}"
+TARBALL="web-ui-${VERSION}.tar.gz"
+
+echo "==> Releasing web-ui ${VERSION} (tag: ${TAG})"
+
+# Ensure working directory is clean
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: Working directory is not clean. Commit or stash changes first."
+  exit 1
+fi
+
+# Install & build
+echo "==> Installing web-ui dependencies…"
+(cd web-ui && bun install --frozen-lockfile)
+
+echo "==> Building web-ui…"
+(cd web-ui && bun run build)
+
+# Package
+echo "==> Packaging .output → ${TARBALL}…"
+tar -czf "${TARBALL}" -C web-ui .output
+
+# Release
+echo "==> Creating GitHub release ${TAG}…"
+gh release create "${TAG}" "${TARBALL}" \
+  --title "web-ui v${VERSION}" \
+  --generate-notes
+
+# Cleanup
+rm -f "${TARBALL}"
+
+echo "✓ Released web-ui v${VERSION} → https://github.com/thiagovarela/lil/releases/tag/${TAG}"
+"""


### PR DESCRIPTION
## Summary

Adds a new `release-web-ui` mise task that automates building, packaging, and publishing the web-ui to GitHub Releases.

## Changes

- **New task**: `mise run release-web-ui [version]`
  - Reads version from root `package.json` (default) or accepts override argument
  - Guards against dirty working directory
  - Installs web-ui dependencies with `bun install --frozen-lockfile`
  - Builds with `bun run build` (Vite + Nitro → `.output/`)
  - Packages `.output/` into `web-ui-<version>.tar.gz`
  - Creates GitHub Release tagged as `web-ui-v<version>` with auto-generated notes
  - Cleans up local tarball

## Usage

```bash
# Release with version from package.json (currently 0.1.0)
mise run release-web-ui

# Release with custom version
mise run release-web-ui 0.2.0
```

## Notes

- Tags are namespaced as `web-ui-v<version>` to avoid collisions with npm package tags
- The tarball contains the full Nitro server (`.output/server/`) + static assets (`.output/public/`)
- Requires clean working directory (same guard as the existing `publish` task)

Closes #45