### PR TITLE
feat: Extensions & Skills management page

### DIFF
--- a/web-ui/bun.lock
+++ b/web-ui/bun.lock
@@ -7,10 +7,9 @@
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@fontsource-variable/inter": "^5.2.8",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.0.6",
-        "@tanstack/react-devtools": "^0.7.0",
         "@tanstack/react-router": "^1.132.0",
-        "@tanstack/react-router-devtools": "^1.132.0",
         "@tanstack/react-router-ssr-query": "^1.131.7",
         "@tanstack/react-start": "^1.132.0",
         "@tanstack/react-store": "^0.9.1",
@@ -31,7 +30,6 @@
         "vite-tsconfig-paths": "^5.1.4",
       },
       "devDependencies": {
-        "@tanstack/devtools-vite": "^0.3.11",
         "@tanstack/eslint-config": "^0.3.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
@@ -427,18 +425,6 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@solid-primitives/event-listener": ["@solid-primitives/event-listener@2.4.5", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA=="],
-
-    "@solid-primitives/keyboard": ["@solid-primitives/keyboard@1.3.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.5", "@solid-primitives/rootless": "^1.5.3", "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ=="],
-
-    "@solid-primitives/resize-observer": ["@solid-primitives/resize-observer@2.1.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.5", "@solid-primitives/rootless": "^1.5.3", "@solid-primitives/static-store": "^0.1.3", "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw=="],
-
-    "@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA=="],
-
-    "@solid-primitives/static-store": ["@solid-primitives/static-store@0.1.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ=="],
-
-    "@solid-primitives/utils": ["@solid-primitives/utils@6.4.0", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A=="],
-
     "@stylistic/eslint-plugin": ["@stylistic/eslint-plugin@5.9.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/types": "^8.56.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "estraverse": "^5.3.0", "picomatch": "^4.0.3" }, "peerDependencies": { "eslint": "^9.0.0 || ^10.0.0" } }, "sha512-FqqSkvDMYJReydrMhlugc71M76yLLQWNfmGq+SIlLa7N3kHp8Qq8i2PyWrVNAfjOyOIY+xv9XaaYwvVW7vroMA=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
@@ -469,19 +455,9 @@
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
 
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
+
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
-
-    "@tanstack/devtools": ["@tanstack/devtools@0.7.0", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.3", "@tanstack/devtools-event-bus": "0.3.3", "@tanstack/devtools-ui": "0.4.4", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-AlAoCqJhWLg9GBEaoV1g/j+X/WA1aJSWOsekxeuZpYeS2hdVuKAjj04KQLUMJhtLfNl2s2E+TCj7ZRtWyY3U4w=="],
-
-    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.5", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.0" } }, "sha512-hsNDE3iu4frt9cC2ppn1mNRnLKo2uc1/1hXAyY9z4UYb+o40M2clFAhiFoo4HngjfGJDV3x18KVVIq7W4Un+zA=="],
-
-    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.3.3", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-lWl88uLAz7ZhwNdLH6A3tBOSEuBCrvnY9Fzr5JPdzJRFdM5ZFdyNWz1Bf5l/F3GU57VodrN0KCFi9OA26H5Kpg=="],
-
-    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.0", "", {}, "sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw=="],
-
-    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.4.4", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-5xHXFyX3nom0UaNfiOM92o6ziaHjGo3mcSGe2HD5Xs8dWRZNpdZ0Smd0B9ddEhy0oB+gXyMzZgUJb9DmrZV0Mg=="],
-
-    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.3.12", "", { "dependencies": { "@babel/core": "^7.28.4", "@babel/generator": "^7.28.3", "@babel/parser": "^7.28.4", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@tanstack/devtools-client": "0.0.5", "@tanstack/devtools-event-bus": "0.3.3", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0" } }, "sha512-fGJgu4xUhKmGk+a+/aHD8l5HKVk6+ObA+6D3YC3xCXbai/YmaGhztqcZf1tKUqjZyYyQLHsjqmKzvJgVpQP1jw=="],
 
     "@tanstack/eslint-config": ["@tanstack/eslint-config@0.3.4", "", { "dependencies": { "@eslint/js": "^9.37.0", "@stylistic/eslint-plugin": "^5.4.0", "eslint-plugin-import-x": "^4.16.1", "eslint-plugin-n": "^17.23.1", "globals": "^16.5.0", "typescript-eslint": "^8.46.0", "vue-eslint-parser": "^10.2.0" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0" } }, "sha512-5Ou1XWJRCTx5G8WoCbT7+6nQ4iNdsISzBAc4lXpFy2fEOO7xioOSPvcPIv+r9V0drPPETou2tr6oLGZZ909FKg=="],
 
@@ -489,13 +465,9 @@
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
-    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.7.11", "", { "dependencies": { "@tanstack/devtools": "0.7.0" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-a2Lmz8x+JoDrsU6f7uKRcyyY+k8mA/n5mb9h7XJ3Fz/y3+sPV9t7vAW1s5lyNkQyyDt6V1Oim99faLthoJSxMw=="],
-
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.163.2", "", { "dependencies": { "@tanstack/history": "1.161.4", "@tanstack/react-store": "^0.9.1", "@tanstack/router-core": "1.163.2", "isbot": "^5.1.22", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-1LosUlpL2mRMWxUZXmkEg5+Br5P5j9TrLngqRgHVbZoFkjnbcj1x9fQN2OVLrBv9Npw97NRsHeJljnAH/c7oSw=="],
-
-    "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.163.2", "", { "dependencies": { "@tanstack/router-devtools-core": "1.163.2" }, "peerDependencies": { "@tanstack/react-router": "^1.163.2", "@tanstack/router-core": "^1.163.2", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-gk/tC+vx8eoNNIM27vfb/bZTXQjpopw7tZA4WkRQWLh9A8PG3V6QjMQysbPcRRO5m7KtdCbTk51ZG4ERi0J1kA=="],
 
     "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.163.2", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.163.2" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-ABt3+XUifb3DGtXVFHPqO1A0+ZE/z/V8zdEJHXhoB0u/sHZ0Ar8UiWka+w87QE3rp9Cn/ySfFlak5q7HvVCPfw=="],
 
@@ -508,8 +480,6 @@
     "@tanstack/react-store": ["@tanstack/react-store@0.9.1", "", { "dependencies": { "@tanstack/store": "0.9.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-YzJLnRvy5lIEFTLWBAZmcOjK3+2AepnBv/sr6NZmiqJvq7zTQggyK99Gw8fqYdMdHPQWXjz0epFKJXC+9V2xDA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.163.2", "", { "dependencies": { "@tanstack/history": "1.161.4", "@tanstack/store": "^0.9.1", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-mD0Pav6kcpS317XSJN+wCZaxLLngDhlwgzPNca56dWCp8YKPEvhhj/Zdl+LdRlJQ2VJ5BOy7FbOV1hErc9Nj5Q=="],
-
-    "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.163.2", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16", "tiny-invariant": "^1.3.3" }, "peerDependencies": { "@tanstack/router-core": "^1.163.2", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-IrbSK30AtMOgCLXTbvhnVsU6BGjhwB8EjfZIQLtUPDvFsP0RH3/2ZiWRA3a0EsQhxkl+fxIVByVP7wgyRzkZPQ=="],
 
     "@tanstack/router-generator": ["@tanstack/router-generator@1.163.2", "", { "dependencies": { "@tanstack/router-core": "1.163.2", "@tanstack/router-utils": "1.161.4", "@tanstack/virtual-file-routes": "1.161.4", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-6LjU3+8iKEgt8iOaYCmCnQCs0jsOhc7z8fa1yAYlj3s82uYWv3g5CB9mwv8wZXblXBQWOl+hW4PI6WNjP/CK9w=="],
 
@@ -727,7 +697,7 @@
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -1009,8 +979,6 @@
 
     "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
-    "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
-
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1144,8 +1112,6 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
-
-    "launch-editor": ["launch-editor@2.13.1", "", { "dependencies": { "picocolors": "^1.1.1", "shell-quote": "^1.8.3" } }, "sha512-lPSddlAAluRKJ7/cjRFoXUFzaX7q/YKI7yPHuEvSJVqoXvFnJov1/Ud87Aa4zULIbA9Nja4mSPK8l0z/7eV2wA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -1407,7 +1373,7 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
@@ -1489,7 +1455,7 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -1507,8 +1473,6 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
-
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -1522,8 +1486,6 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
-
-    "solid-js": ["solid-js@1.9.11", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -1759,7 +1721,13 @@
 
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -1791,15 +1759,11 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tanstack/devtools/@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.3", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.3.3" } }, "sha512-kl0r6N5iIL3t9gGDRAv55VRM3UIyMKVH83esRGq7xBjYsRLe/BeCIN2HqrlJkObUXQMKhy7i8ejuGOn+bDqDBw=="],
-
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
 
     "@tanstack/start-plugin-core/srvx": ["srvx@0.11.7", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-p9qj9wkv/MqG1VoJpOsqXv1QcaVcYRk7ifsC6i3TEwDXFyugdhJN4J3KzQPZq2IJJ2ZCt7ASOB++85pEK38jRw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
@@ -1808,6 +1772,8 @@
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -1827,19 +1793,11 @@
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
-    "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint/minimatch": ["minimatch@3.1.4", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw=="],
 
-    "eslint-compat-utils/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "eslint-plugin-import-x/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "eslint-plugin-n/globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
-
-    "eslint-plugin-n/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -1851,6 +1809,8 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -1858,6 +1818,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -1877,6 +1839,8 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
@@ -1884,8 +1848,6 @@
     "vue-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "vue-eslint-parser/espree": ["espree@11.1.1", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ=="],
-
-    "vue-eslint-parser/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -1915,8 +1877,6 @@
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@tanstack/devtools/@tanstack/devtools-client/@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.3.5", "", {}, "sha512-RL1f5ZlfZMpghrCIdzl6mLOFLTuhqmPNblZgBaeKfdtk5rfbjykurv+VfYydOFXj0vxVIoA2d/zT7xfD7Ph8fw=="],
-
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1924,8 +1884,6 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/web-ui/src/components/session-sidebar.tsx
+++ b/web-ui/src/components/session-sidebar.tsx
@@ -1,82 +1,71 @@
-import { useStore } from '@tanstack/react-store'
-import { MessageSquare, Plus } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
-import { sessionsListStore } from '@/stores/sessions-list'
-import { clientManager } from '@/lib/client-manager'
-import { cn } from '@/lib/utils'
+import { useStore } from "@tanstack/react-store";
+import { MessageSquare, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { clientManager } from "@/lib/client-manager";
+import { cn } from "@/lib/utils";
+import { sessionsListStore } from "@/stores/sessions-list";
 
 export function SessionSidebar() {
-  const { sessions, activeSessionId } = useStore(
-    sessionsListStore,
-    (state) => ({
-      sessions: state.sessions,
-      activeSessionId: state.activeSessionId,
-    }),
-  )
+	const { sessions, activeSessionId } = useStore(sessionsListStore, (state) => ({
+		sessions: state.sessions,
+		activeSessionId: state.activeSessionId,
+	}));
 
-  const handleNewChat = async () => {
-    await clientManager.createNewSession()
-  }
+	const handleNewChat = async () => {
+		await clientManager.createNewSession();
+	};
 
-  const handleSelectSession = (sessionId: string) => {
-    if (sessionId === activeSessionId) return
-    clientManager.switchSession(sessionId)
-  }
+	const handleSelectSession = (sessionId: string) => {
+		if (sessionId === activeSessionId) return;
+		clientManager.switchSession(sessionId);
+	};
 
-  return (
-    <div className="flex h-full w-64 flex-col border-r border-sidebar-border bg-sidebar">
-      <div className="p-4">
-        <Button onClick={handleNewChat} className="w-full" size="sm">
-          <Plus className="mr-2 h-4 w-4" />
-          New Chat
-        </Button>
-      </div>
+	return (
+		<div className="flex h-full w-64 flex-col border-r border-sidebar-border bg-sidebar">
+			<div className="p-4">
+				<Button onClick={handleNewChat} className="w-full" size="sm">
+					<Plus className="mr-2 h-4 w-4" />
+					New Chat
+				</Button>
+			</div>
 
-      <Separator />
+			<Separator />
 
-      <div className="flex-1 overflow-y-auto p-2">
-        {sessions.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-32 text-center p-4">
-            <MessageSquare className="h-8 w-8 text-sidebar-foreground/50 mb-2" />
-            <p className="text-sm text-sidebar-foreground/70">
-              No sessions yet
-            </p>
-            <p className="text-xs text-sidebar-foreground/50">
-              Click "New Chat" to start
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-1">
-            {sessions.map((session) => (
-              <button
-                key={session.sessionId}
-                onClick={() => handleSelectSession(session.sessionId)}
-                className={cn(
-                  'w-full rounded-md p-3 text-left transition-colors',
-                  'hover:bg-sidebar-accent',
-                  session.sessionId === activeSessionId
-                    ? 'bg-sidebar-accent'
-                    : 'bg-transparent',
-                )}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-sidebar-foreground truncate">
-                      {session.title || 'New chat'}
-                    </p>
-                  </div>
-                  {session.messageCount > 0 && (
-                    <span className="text-xs text-sidebar-foreground/50 shrink-0">
-                      {session.messageCount}
-                    </span>
-                  )}
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  )
+			<div className="flex-1 overflow-y-auto p-2">
+				{sessions.length === 0 ? (
+					<div className="flex flex-col items-center justify-center h-32 text-center p-4">
+						<MessageSquare className="h-8 w-8 text-sidebar-foreground/50 mb-2" />
+						<p className="text-sm text-sidebar-foreground/70">No sessions yet</p>
+						<p className="text-xs text-sidebar-foreground/50">Click "New Chat" to start</p>
+					</div>
+				) : (
+					<div className="space-y-1">
+						{sessions.map((session) => (
+							<button
+								key={session.sessionId}
+								onClick={() => handleSelectSession(session.sessionId)}
+								className={cn(
+									"w-full rounded-md p-3 text-left transition-colors",
+									"hover:bg-sidebar-accent",
+									session.sessionId === activeSessionId ? "bg-sidebar-accent" : "bg-transparent",
+								)}
+							>
+								<div className="flex items-start justify-between gap-2">
+									<div className="flex-1 min-w-0">
+										<p className="text-sm font-medium text-sidebar-foreground truncate">
+											{session.title || "New chat"}
+										</p>
+									</div>
+									{session.messageCount > 0 && (
+										<span className="text-xs text-sidebar-foreground/50 shrink-0">{session.messageCount}</span>
+									)}
+								</div>
+							</button>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -171,6 +171,67 @@ export class ClankieClient {
 		await this.sendCommand({ type: "auth_logout", providerId });
 	}
 
+	// ─── Extensions & Skills ───────────────────────────────────────────────────
+
+	async getExtensions(sessionId: string): Promise<{
+		extensions: Array<{
+			path: string;
+			resolvedPath: string;
+			tools: string[];
+			commands: string[];
+			flags: string[];
+			shortcuts: string[];
+		}>;
+		errors: Array<{ path: string; error: string }>;
+	}> {
+		const response = await this.sendCommand({ type: "get_extensions" }, sessionId);
+		return response as {
+			extensions: Array<{
+				path: string;
+				resolvedPath: string;
+				tools: string[];
+				commands: string[];
+				flags: string[];
+				shortcuts: string[];
+			}>;
+			errors: Array<{ path: string; error: string }>;
+		};
+	}
+
+	async getSkills(sessionId: string): Promise<{
+		skills: Array<{
+			name: string;
+			description: string;
+			filePath: string;
+			baseDir: string;
+			source: string;
+			disableModelInvocation: boolean;
+		}>;
+		diagnostics: Array<{ type: string; message: string; path?: string }>;
+	}> {
+		const response = await this.sendCommand({ type: "get_skills" }, sessionId);
+		return response as {
+			skills: Array<{
+				name: string;
+				description: string;
+				filePath: string;
+				baseDir: string;
+				source: string;
+				disableModelInvocation: boolean;
+			}>;
+			diagnostics: Array<{ type: string; message: string; path?: string }>;
+		};
+	}
+
+	async installPackage(
+		sessionId: string,
+		source: string,
+		local?: boolean,
+	): Promise<{ output: string; exitCode: number }> {
+		const response = await this.sendCommand({ type: "install_package", source, local }, sessionId);
+		return response as { output: string; exitCode: number };
+	}
+
 	// ─── Internal ──────────────────────────────────────────────────────────────
 
 	private handleMessage(message: OutboundWebMessage | RpcResponse): void {

--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -91,7 +91,7 @@ class ClientManager {
 
 			// Try to restore the last active session from localStorage
 			const savedSessionId = localStorage.getItem("clankie-last-session-id");
-			
+
 			if (savedSessionId) {
 				console.log(`[client-manager] Attempting to restore session: ${savedSessionId}`);
 				try {
@@ -400,12 +400,10 @@ class ClientManager {
 
 			// Add to sessions list if not already there
 			const { sessions } = sessionsListStore.state;
-			if (!sessions.some(s => s.sessionId === sessionId)) {
+			if (!sessions.some((s) => s.sessionId === sessionId)) {
 				// Get the last user message as the title
-				const lastUserMessage = [...messages]
-					.reverse()
-					.find((msg) => msg.role === "user");
-				
+				const lastUserMessage = [...messages].reverse().find((msg) => msg.role === "user");
+
 				let title: string | undefined;
 				if (lastUserMessage) {
 					const textContent = lastUserMessage.content

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -43,6 +43,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_session_name"; name: string }
 	| { id?: string; type: "get_messages" }
 	| { id?: string; type: "get_commands" }
+	| { id?: string; type: "get_extensions" }
+	| { id?: string; type: "get_skills" }
+	| { id?: string; type: "install_package"; source: string; local?: boolean }
 	| { id?: string; type: "get_auth_providers" }
 	| { id?: string; type: "auth_login"; providerId: string }
 	| { id?: string; type: "auth_set_api_key"; providerId: string; apiKey: string }
@@ -182,6 +185,37 @@ export type AuthEvent =
 	| { type: "auth_event"; loginFlowId: string; event: "manual_input" }
 	| { type: "auth_event"; loginFlowId: string; event: "progress"; message: string }
 	| { type: "auth_event"; loginFlowId: string; event: "complete"; success: boolean; error?: string };
+
+// ─── Extensions & Skills ───────────────────────────────────────────────────────
+
+export interface ExtensionInfo {
+	path: string;
+	resolvedPath: string;
+	tools: string[];
+	commands: string[];
+	flags: string[];
+	shortcuts: string[];
+}
+
+export interface ExtensionError {
+	path: string;
+	error: string;
+}
+
+export interface SkillInfo {
+	name: string;
+	description: string;
+	filePath: string;
+	baseDir: string;
+	source: string;
+	disableModelInvocation: boolean;
+}
+
+export interface SkillDiagnostic {
+	type: string;
+	message: string;
+	path?: string;
+}
 
 // ─── WebSocket Message Wrapper ─────────────────────────────────────────────────
 

--- a/web-ui/src/routeTree.gen.ts
+++ b/web-ui/src/routeTree.gen.ts
@@ -10,11 +10,17 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ExtensionsRouteImport } from './routes/extensions'
 import { Route as IndexRouteImport } from './routes/index'
 
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ExtensionsRoute = ExtensionsRouteImport.update({
+  id: '/extensions',
+  path: '/extensions',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -25,27 +31,31 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/extensions': typeof ExtensionsRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/extensions': typeof ExtensionsRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/extensions': typeof ExtensionsRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/settings'
+  fullPaths: '/' | '/extensions' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/settings'
-  id: '__root__' | '/' | '/settings'
+  to: '/' | '/extensions' | '/settings'
+  id: '__root__' | '/' | '/extensions' | '/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ExtensionsRoute: typeof ExtensionsRoute
   SettingsRoute: typeof SettingsRoute
 }
 
@@ -56,6 +66,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/extensions': {
+      id: '/extensions'
+      path: '/extensions'
+      fullPath: '/extensions'
+      preLoaderRoute: typeof ExtensionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -70,17 +87,9 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ExtensionsRoute: ExtensionsRoute,
   SettingsRoute: SettingsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/web-ui/src/routes/__root.tsx
+++ b/web-ui/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { createRootRoute, HeadContent, Link, Outlet, Scripts } from "@tanstack/react-router";
-import { MessageSquare, Settings } from "lucide-react";
+import { MessageSquare, Puzzle, Settings } from "lucide-react";
 import { useEffect } from "react";
 import { ConnectionStatus } from "@/components/connection-status";
 import { clientManager } from "@/lib/client-manager";
@@ -55,6 +55,13 @@ function RootComponent() {
 							>
 								<MessageSquare className="h-4 w-4" />
 								Chat
+							</Link>
+							<Link
+								to="/extensions"
+								className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-accent [&.active]:bg-accent"
+							>
+								<Puzzle className="h-4 w-4" />
+								Extensions & Skills
 							</Link>
 							<Link
 								to="/settings"

--- a/web-ui/src/routes/extensions.tsx
+++ b/web-ui/src/routes/extensions.tsx
@@ -1,0 +1,391 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useStore } from "@tanstack/react-store";
+import { AlertCircle, CheckCircle, Loader2, Package, Puzzle, Settings, Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { clientManager } from "@/lib/client-manager";
+import { connectionStore } from "@/stores/connection";
+import {
+	extensionsStore,
+	resetInstallStatus,
+	setExtensions,
+	setInstallStatus,
+	setLoading,
+	setSkills,
+} from "@/stores/extensions";
+import { sessionsListStore } from "@/stores/sessions-list";
+
+export const Route = createFileRoute("/extensions")({
+	component: ExtensionsPage,
+});
+
+function ExtensionsPage() {
+	const { status } = useStore(connectionStore, (state) => ({
+		status: state.status,
+	}));
+
+	const { activeSessionId } = useStore(sessionsListStore, (state) => ({
+		activeSessionId: state.activeSessionId,
+	}));
+
+	const { extensions, extensionErrors, skills, skillDiagnostics, isLoading, installStatus } = useStore(
+		extensionsStore,
+		(state) => state,
+	);
+
+	const [packageSource, setPackageSource] = useState("");
+	const [installLocal, setInstallLocal] = useState(false);
+
+	const isConnected = status === "connected";
+
+	useEffect(() => {
+		if (isConnected && activeSessionId) {
+			loadExtensionsAndSkills();
+		}
+	}, [isConnected, activeSessionId]);
+
+	const loadExtensionsAndSkills = async () => {
+		const client = clientManager.getClient();
+		if (!client || !activeSessionId) return;
+
+		setLoading(true);
+		try {
+			const [extensionsResult, skillsResult] = await Promise.all([
+				client.getExtensions(activeSessionId),
+				client.getSkills(activeSessionId),
+			]);
+
+			setExtensions(extensionsResult.extensions, extensionsResult.errors);
+			setSkills(skillsResult.skills, skillsResult.diagnostics);
+		} catch (err) {
+			console.error("Failed to load extensions and skills:", err);
+			setLoading(false);
+		}
+	};
+
+	const handleInstall = async () => {
+		const client = clientManager.getClient();
+		if (!client || !activeSessionId || !packageSource.trim()) return;
+
+		setInstallStatus({ isInstalling: true, output: "", exitCode: null, error: undefined });
+
+		try {
+			const result = await client.installPackage(activeSessionId, packageSource.trim(), installLocal);
+
+			setInstallStatus({
+				isInstalling: false,
+				output: result.output,
+				exitCode: result.exitCode,
+			});
+
+			// If successful, reload extensions and skills
+			if (result.exitCode === 0) {
+				await loadExtensionsAndSkills();
+			}
+		} catch (err) {
+			setInstallStatus({
+				isInstalling: false,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	};
+
+	if (!isConnected) {
+		return (
+			<div className="flex h-full items-center justify-center">
+				<div className="text-center space-y-4">
+					<div className="space-y-2">
+						<h2 className="text-2xl font-semibold">Not Connected</h2>
+						<p className="text-muted-foreground">Configure your connection to get started</p>
+					</div>
+					<Link to="/settings">
+						<Button>
+							<Settings className="mr-2 h-4 w-4" />
+							Go to Settings
+						</Button>
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex h-full items-center justify-center">
+				<div className="text-center space-y-2">
+					<Loader2 className="inline-block h-8 w-8 animate-spin text-primary" />
+					<p className="text-sm text-muted-foreground">Loading extensions and skills...</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="h-full overflow-y-auto">
+			<div className="container max-w-4xl py-8 px-4 space-y-6">
+				{/* Extensions Section */}
+				<Card>
+					<CardHeader>
+						<CardTitle className="flex items-center gap-2">
+							<Puzzle className="h-5 w-5" />
+							Extensions
+						</CardTitle>
+						<CardDescription>Loaded extensions with their registered tools and commands</CardDescription>
+					</CardHeader>
+					<CardContent>
+						{extensionErrors.length > 0 && (
+							<div className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 p-3">
+								<div className="flex items-start gap-2">
+									<AlertCircle className="h-4 w-4 text-destructive mt-0.5" />
+									<div className="flex-1">
+										<p className="text-sm font-medium text-destructive">Extension Load Errors</p>
+										<div className="mt-2 space-y-2">
+											{extensionErrors.map((err, idx) => (
+												<div key={idx} className="text-xs">
+													<p className="font-mono text-muted-foreground">{err.path}</p>
+													<p className="text-destructive">{err.error}</p>
+												</div>
+											))}
+										</div>
+									</div>
+								</div>
+							</div>
+						)}
+
+						{extensions.length === 0 ? (
+							<p className="text-sm text-muted-foreground py-4">No extensions loaded.</p>
+						) : (
+							<div className="space-y-3">
+								{extensions.map((ext, idx) => (
+									<div key={idx} className="rounded-lg border p-3">
+										<div className="space-y-2">
+											<div>
+												<p className="text-sm font-medium font-mono break-all">{ext.path}</p>
+												{ext.resolvedPath !== ext.path && (
+													<p className="text-xs text-muted-foreground font-mono mt-1 break-all">→ {ext.resolvedPath}</p>
+												)}
+											</div>
+
+											<div className="flex flex-wrap gap-2">
+												{ext.tools.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														<span className="text-xs text-muted-foreground mr-1">Tools:</span>
+														{ext.tools.map((tool) => (
+															<Badge key={tool} variant="secondary" className="text-xs">
+																{tool}
+															</Badge>
+														))}
+													</div>
+												)}
+
+												{ext.commands.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														<span className="text-xs text-muted-foreground mr-1">Commands:</span>
+														{ext.commands.map((cmd) => (
+															<Badge key={cmd} variant="default" className="text-xs">
+																/{cmd}
+															</Badge>
+														))}
+													</div>
+												)}
+
+												{ext.flags.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														<span className="text-xs text-muted-foreground mr-1">Flags:</span>
+														{ext.flags.map((flag) => (
+															<Badge key={flag} variant="outline" className="text-xs">
+																--{flag}
+															</Badge>
+														))}
+													</div>
+												)}
+
+												{ext.shortcuts.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														<span className="text-xs text-muted-foreground mr-1">Shortcuts:</span>
+														{ext.shortcuts.map((shortcut) => (
+															<Badge key={shortcut} variant="outline" className="text-xs font-mono">
+																{shortcut}
+															</Badge>
+														))}
+													</div>
+												)}
+											</div>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</CardContent>
+				</Card>
+
+				{/* Skills Section */}
+				<Card>
+					<CardHeader>
+						<CardTitle className="flex items-center gap-2">
+							<Sparkles className="h-5 w-5" />
+							Skills
+						</CardTitle>
+						<CardDescription>Available skills for the agent</CardDescription>
+					</CardHeader>
+					<CardContent>
+						{skillDiagnostics.length > 0 && (
+							<div className="mb-4 rounded-md border border-yellow-500/50 bg-yellow-500/10 p-3">
+								<div className="flex items-start gap-2">
+									<AlertCircle className="h-4 w-4 text-yellow-600 mt-0.5" />
+									<div className="flex-1">
+										<p className="text-sm font-medium text-yellow-600">Skill Diagnostics</p>
+										<div className="mt-2 space-y-1">
+											{skillDiagnostics.map((diag, idx) => (
+												<p key={idx} className="text-xs text-yellow-700">
+													{diag.path && <span className="font-mono">{diag.path}: </span>}
+													{diag.message}
+												</p>
+											))}
+										</div>
+									</div>
+								</div>
+							</div>
+						)}
+
+						{skills.length === 0 ? (
+							<p className="text-sm text-muted-foreground py-4">No skills loaded.</p>
+						) : (
+							<div className="space-y-3">
+								{skills.map((skill, idx) => (
+									<div key={idx} className="rounded-lg border p-3">
+										<div className="space-y-2">
+											<div className="flex items-start justify-between gap-2">
+												<div className="flex-1">
+													<div className="flex items-center gap-2">
+														<p className="text-sm font-medium">{skill.name}</p>
+														{skill.disableModelInvocation && (
+															<Badge variant="outline" className="text-xs">
+																Manual only
+															</Badge>
+														)}
+													</div>
+													<p className="text-xs text-muted-foreground mt-1">{skill.description}</p>
+												</div>
+											</div>
+
+											<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+												<span>
+													<span className="font-medium">Source:</span> {skill.source}
+												</span>
+												<span>•</span>
+												<span className="font-mono break-all">{skill.filePath}</span>
+											</div>
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</CardContent>
+				</Card>
+
+				{/* Install Package Section */}
+				<Card>
+					<CardHeader>
+						<CardTitle className="flex items-center gap-2">
+							<Package className="h-5 w-5" />
+							Install Package
+						</CardTitle>
+						<CardDescription>Install a Pi package from npm, git, or a local path</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<Field>
+							<FieldLabel htmlFor="package-source">Package Source</FieldLabel>
+							<Input
+								id="package-source"
+								type="text"
+								placeholder="npm:@foo/bar@1.0.0, git:github.com/user/repo, or /path/to/package"
+								value={packageSource}
+								onChange={(e) => setPackageSource(e.target.value)}
+								disabled={installStatus.isInstalling}
+							/>
+							<p className="text-xs text-muted-foreground mt-1">
+								Examples: <code className="text-xs">npm:package-name</code>,{" "}
+								<code className="text-xs">git:github.com/user/repo</code>,{" "}
+								<code className="text-xs">/absolute/path</code>
+							</p>
+						</Field>
+
+						<div className="flex items-center gap-2">
+							<input
+								type="checkbox"
+								id="install-local"
+								checked={installLocal}
+								onChange={(e) => setInstallLocal(e.target.checked)}
+								disabled={installStatus.isInstalling}
+								className="h-4 w-4"
+							/>
+							<label htmlFor="install-local" className="text-sm cursor-pointer">
+								Install to project settings (.pi/settings.json) instead of global
+							</label>
+						</div>
+
+						<div className="flex gap-2">
+							<Button
+								onClick={handleInstall}
+								disabled={installStatus.isInstalling || !packageSource.trim()}
+								className="flex-1"
+							>
+								{installStatus.isInstalling ? (
+									<>
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										Installing...
+									</>
+								) : (
+									<>
+										<Package className="mr-2 h-4 w-4" />
+										Install
+									</>
+								)}
+							</Button>
+							{(installStatus.output || installStatus.error) && (
+								<Button variant="outline" onClick={resetInstallStatus}>
+									Clear
+								</Button>
+							)}
+						</div>
+
+						{installStatus.error && (
+							<div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+								<p className="font-medium">Error</p>
+								<p className="text-xs mt-1">{installStatus.error}</p>
+							</div>
+						)}
+
+						{installStatus.output && (
+							<div className="space-y-2">
+								<div className="flex items-center gap-2">
+									{installStatus.exitCode === 0 ? (
+										<>
+											<CheckCircle className="h-4 w-4 text-green-600" />
+											<p className="text-sm font-medium text-green-600">Installation Successful</p>
+										</>
+									) : (
+										<>
+											<AlertCircle className="h-4 w-4 text-destructive" />
+											<p className="text-sm font-medium text-destructive">
+												Installation Failed (exit code: {installStatus.exitCode})
+											</p>
+										</>
+									)}
+								</div>
+								<div className="rounded-md bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-all max-h-60 overflow-y-auto">
+									{installStatus.output}
+								</div>
+							</div>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+		</div>
+	);
+}

--- a/web-ui/src/routes/settings.tsx
+++ b/web-ui/src/routes/settings.tsx
@@ -47,63 +47,63 @@ function SettingsPage() {
 			<div className="container max-w-2xl py-8 px-4">
 				<Card>
 					<CardHeader>
-					<CardTitle>Connection Settings</CardTitle>
-					<CardDescription>Configure the WebSocket connection to your clankie instance</CardDescription>
-				</CardHeader>
-				<CardContent className="space-y-4">
-					<Field>
-						<FieldLabel htmlFor="ws-url">WebSocket URL</FieldLabel>
-						<Input
-							id="ws-url"
-							type="text"
-							placeholder="ws://localhost:3100"
-							value={url}
-							onChange={(e) => setUrl(e.target.value)}
-							disabled={isConnected}
-						/>
-					</Field>
+						<CardTitle>Connection Settings</CardTitle>
+						<CardDescription>Configure the WebSocket connection to your clankie instance</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-4">
+						<Field>
+							<FieldLabel htmlFor="ws-url">WebSocket URL</FieldLabel>
+							<Input
+								id="ws-url"
+								type="text"
+								placeholder="ws://localhost:3100"
+								value={url}
+								onChange={(e) => setUrl(e.target.value)}
+								disabled={isConnected}
+							/>
+						</Field>
 
-					<Field>
-						<FieldLabel htmlFor="auth-token">Auth Token</FieldLabel>
-						<Input
-							id="auth-token"
-							type="password"
-							placeholder="Enter your authentication token"
-							value={authToken}
-							onChange={(e) => setAuthToken(e.target.value)}
-							disabled={isConnected}
-						/>
-						<p className="text-xs text-muted-foreground mt-1">
-							Set with:{" "}
-							<code className="rounded bg-muted px-1 py-0.5">
-								clankie config set channels.web.authToken "your-token"
-							</code>
-						</p>
-					</Field>
+						<Field>
+							<FieldLabel htmlFor="auth-token">Auth Token</FieldLabel>
+							<Input
+								id="auth-token"
+								type="password"
+								placeholder="Enter your authentication token"
+								value={authToken}
+								onChange={(e) => setAuthToken(e.target.value)}
+								disabled={isConnected}
+							/>
+							<p className="text-xs text-muted-foreground mt-1">
+								Set with:{" "}
+								<code className="rounded bg-muted px-1 py-0.5">
+									clankie config set channels.web.authToken "your-token"
+								</code>
+							</p>
+						</Field>
 
-					<div className="flex gap-2 pt-2">
-						{!isConnected ? (
-							<>
-								<Button onClick={handleConnect} disabled={isConnecting || !authToken}>
-									{isConnecting ? "Connecting..." : "Connect"}
+						<div className="flex gap-2 pt-2">
+							{!isConnected ? (
+								<>
+									<Button onClick={handleConnect} disabled={isConnecting || !authToken}>
+										{isConnecting ? "Connecting..." : "Connect"}
+									</Button>
+									<Button variant="outline" onClick={handleSave} disabled={isConnecting}>
+										Save
+									</Button>
+								</>
+							) : (
+								<Button variant="destructive" onClick={handleDisconnect}>
+									Disconnect
 								</Button>
-								<Button variant="outline" onClick={handleSave} disabled={isConnecting}>
-									Save
-								</Button>
-							</>
-						) : (
-							<Button variant="destructive" onClick={handleDisconnect}>
-								Disconnect
-							</Button>
-						)}
-					</div>
-
-					{!authToken && (
-						<div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-							<p className="font-medium">Auth token required</p>
-							<p className="text-xs mt-1">Configure the token in clankie and enter it above to connect.</p>
+							)}
 						</div>
-					)}
+
+						{!authToken && (
+							<div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+								<p className="font-medium">Auth token required</p>
+								<p className="text-xs mt-1">Configure the token in clankie and enter it above to connect.</p>
+							</div>
+						)}
 					</CardContent>
 				</Card>
 
@@ -112,26 +112,26 @@ function SettingsPage() {
 						<CardTitle>Setup Instructions</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-3 text-sm">
-					<div>
-						<p className="font-medium">1. Enable the web channel in clankie</p>
-						<code className="block mt-1 rounded bg-muted p-2 text-xs">
-							clankie config set channels.web.authToken "your-secret-token"
-							<br />
-							clankie config set channels.web.port 3100
-						</code>
-					</div>
+						<div>
+							<p className="font-medium">1. Enable the web channel in clankie</p>
+							<code className="block mt-1 rounded bg-muted p-2 text-xs">
+								clankie config set channels.web.authToken "your-secret-token"
+								<br />
+								clankie config set channels.web.port 3100
+							</code>
+						</div>
 
-					<div>
-						<p className="font-medium">2. Start the clankie daemon</p>
-						<code className="block mt-1 rounded bg-muted p-2 text-xs">clankie start</code>
-					</div>
+						<div>
+							<p className="font-medium">2. Start the clankie daemon</p>
+							<code className="block mt-1 rounded bg-muted p-2 text-xs">clankie start</code>
+						</div>
 
-					<div>
-						<p className="font-medium">3. Enter the token above and connect</p>
-						<p className="text-xs text-muted-foreground mt-1">
-							The web-ui will connect to ws://localhost:3100 by default
-						</p>
-					</div>
+						<div>
+							<p className="font-medium">3. Enter the token above and connect</p>
+							<p className="text-xs text-muted-foreground mt-1">
+								The web-ui will connect to ws://localhost:3100 by default
+							</p>
+						</div>
 					</CardContent>
 				</Card>
 

--- a/web-ui/src/stores/extensions.ts
+++ b/web-ui/src/stores/extensions.ts
@@ -1,0 +1,90 @@
+/**
+ * Extensions store — manages extensions and skills state.
+ */
+
+import { Store } from "@tanstack/store";
+import type { ExtensionError, ExtensionInfo, SkillDiagnostic, SkillInfo } from "@/lib/types";
+
+export interface InstallStatus {
+	isInstalling: boolean;
+	output: string;
+	exitCode: number | null;
+	error?: string;
+}
+
+export interface ExtensionsStore {
+	extensions: ExtensionInfo[];
+	extensionErrors: ExtensionError[];
+	skills: SkillInfo[];
+	skillDiagnostics: SkillDiagnostic[];
+	isLoading: boolean;
+	installStatus: InstallStatus;
+}
+
+const INITIAL_STATE: ExtensionsStore = {
+	extensions: [],
+	extensionErrors: [],
+	skills: [],
+	skillDiagnostics: [],
+	isLoading: false,
+	installStatus: {
+		isInstalling: false,
+		output: "",
+		exitCode: null,
+	},
+};
+
+export const extensionsStore = new Store<ExtensionsStore>(INITIAL_STATE);
+
+// ─── Actions ───────────────────────────────────────────────────────────────────
+
+export function setLoading(loading: boolean): void {
+	extensionsStore.setState((state) => ({
+		...state,
+		isLoading: loading,
+	}));
+}
+
+export function setExtensions(extensions: ExtensionInfo[], errors: ExtensionError[]): void {
+	extensionsStore.setState((state) => ({
+		...state,
+		extensions,
+		extensionErrors: errors,
+		isLoading: false,
+	}));
+}
+
+export function setSkills(skills: SkillInfo[], diagnostics: SkillDiagnostic[]): void {
+	extensionsStore.setState((state) => ({
+		...state,
+		skills,
+		skillDiagnostics: diagnostics,
+		isLoading: false,
+	}));
+}
+
+export function setInstallStatus(status: Partial<InstallStatus>): void {
+	extensionsStore.setState((state) => ({
+		...state,
+		installStatus: {
+			...state.installStatus,
+			...status,
+		},
+	}));
+}
+
+export function resetInstallStatus(): void {
+	extensionsStore.setState((state) => ({
+		...state,
+		installStatus: {
+			isInstalling: false,
+			output: "",
+			exitCode: null,
+			error: undefined,
+		},
+	}));
+}
+
+export function resetExtensions(): void {
+	extensionsStore.setState(INITIAL_STATE);
+}

--- a/web-ui/src/stores/sessions-list.ts
+++ b/web-ui/src/stores/sessions-list.ts
@@ -3,72 +3,69 @@
  * and tracks which one is currently active.
  */
 
-import { Store } from '@tanstack/store'
+import { Store } from "@tanstack/store";
 
 export interface SessionListItem {
-  sessionId: string
-  title?: string
-  messageCount: number
-  createdAt: number
+	sessionId: string;
+	title?: string;
+	messageCount: number;
+	createdAt: number;
 }
 
 export interface SessionsListStore {
-  sessions: Array<SessionListItem>
-  activeSessionId: string | null
+	sessions: Array<SessionListItem>;
+	activeSessionId: string | null;
 }
 
 const INITIAL_STATE: SessionsListStore = {
-  sessions: [],
-  activeSessionId: null,
-}
+	sessions: [],
+	activeSessionId: null,
+};
 
-export const sessionsListStore = new Store<SessionsListStore>(INITIAL_STATE)
+export const sessionsListStore = new Store<SessionsListStore>(INITIAL_STATE);
 
 // ─── Actions ───────────────────────────────────────────────────────────────────
 
 export function addSession(session: SessionListItem): void {
-  sessionsListStore.setState((state) => {
-    // Don't add duplicates
-    if (state.sessions.some((s) => s.sessionId === session.sessionId)) {
-      return state
-    }
+	sessionsListStore.setState((state) => {
+		// Don't add duplicates
+		if (state.sessions.some((s) => s.sessionId === session.sessionId)) {
+			return state;
+		}
 
-    return {
-      ...state,
-      sessions: [...state.sessions, session],
-    }
-  })
+		return {
+			...state,
+			sessions: [...state.sessions, session],
+		};
+	});
 }
 
 export function removeSession(sessionId: string): void {
-  sessionsListStore.setState((state) => ({
-    ...state,
-    sessions: state.sessions.filter((s) => s.sessionId !== sessionId),
-    // Clear active if removing active session
-    activeSessionId:
-      state.activeSessionId === sessionId ? null : state.activeSessionId,
-  }))
+	sessionsListStore.setState((state) => ({
+		...state,
+		sessions: state.sessions.filter((s) => s.sessionId !== sessionId),
+		// Clear active if removing active session
+		activeSessionId: state.activeSessionId === sessionId ? null : state.activeSessionId,
+	}));
 }
 
 export function setActiveSession(sessionId: string): void {
-  sessionsListStore.setState((state) => ({
-    ...state,
-    activeSessionId: sessionId,
-  }))
+	sessionsListStore.setState((state) => ({
+		...state,
+		activeSessionId: sessionId,
+	}));
 }
 
 export function updateSessionMeta(
-  sessionId: string,
-  updates: Partial<Omit<SessionListItem, 'sessionId' | 'createdAt'>>,
+	sessionId: string,
+	updates: Partial<Omit<SessionListItem, "sessionId" | "createdAt">>,
 ): void {
-  sessionsListStore.setState((state) => ({
-    ...state,
-    sessions: state.sessions.map((s) =>
-      s.sessionId === sessionId ? { ...s, ...updates } : s,
-    ),
-  }))
+	sessionsListStore.setState((state) => ({
+		...state,
+		sessions: state.sessions.map((s) => (s.sessionId === sessionId ? { ...s, ...updates } : s)),
+	}));
 }
 
 export function clearSessions(): void {
-  sessionsListStore.setState(INITIAL_STATE)
+	sessionsListStore.setState(INITIAL_STATE);
 }


### PR DESCRIPTION
## Summary

Adds a new **Extensions & Skills** page to the web UI, allowing users to:
- View loaded extensions with their registered tools, commands, flags, and shortcuts
- View loaded skills with descriptions and sources
- Install Pi packages (npm, git, or local paths) directly from the UI
- See real-time installation output and error messages

Closes #46

## Changes

### Backend

- Added get_extensions RPC command - returns loaded extensions with metadata
- Added get_skills RPC command - returns loaded skills with metadata  
- Added install_package RPC command - runs pi install via bash executor and reloads session

### Frontend

**Types & Client**
- Added ExtensionInfo, SkillInfo, ExtensionError, SkillDiagnostic interfaces
- Added RPC command types for new endpoints
- Added client methods: getExtensions(), getSkills(), installPackage()

**Store**
- New store for extensions/skills state and install status
- Actions for loading, updating, and resetting state

**Route**
- New /extensions page with three sections:
  - Extensions: Lists paths, tools (badges), commands (badges), flags, shortcuts, and load errors
  - Skills: Lists names, descriptions, sources, file paths, and manual-only markers
  - Install Package: Input for npm/git/local sources, local scope checkbox, install button, and output display
- Auto-loads data when connected and session is active
- Re-fetches extensions/skills after successful install

**Navigation**
- Added Extensions & Skills nav link with Puzzle icon between Chat and Settings

## Testing

- Successfully loads extensions and skills on mount
- Displays extension load errors clearly
- Installs npm packages, git packages, and local packages
- Local scope checkbox works (-l flag)
- Shows install output and exit code
- Re-loads extensions/skills after successful install
- Handles install errors gracefully
- Shows Not Connected state when disconnected
- Shows loading spinner while fetching data

## Notes

- Uses session.executeBash() to run pi install instead of importing PackageManager directly
- After successful install, calls session.reload() to pick up new extensions/skills
- Extension errors and skill diagnostics are displayed prominently
- The install command assumes pi is available in PATH on the server
