### PR TITLE
fix(web): pass sessionId to executeCommand for event broadcasting

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -379,7 +379,7 @@ export class WebChannel implements Channel {
 			}
 
 			// Execute command (mirrors rpc-mode.ts logic)
-			const response = await this.executeCommand(session, command);
+			const response = await this.executeCommand(sessionId, session, command);
 			this.sendResponse(ws, sessionId, response);
 		} catch (err) {
 			console.error("[web] Command error:", err);
@@ -387,7 +387,7 @@ export class WebChannel implements Channel {
 		}
 	}
 
-	private async executeCommand(session: AgentSession, command: RpcCommand): Promise<RpcResponse> {
+	private async executeCommand(sessionId: string, session: AgentSession, command: RpcCommand): Promise<RpcResponse> {
 		const id = command.id;
 
 		switch (command.type) {


### PR DESCRIPTION
## Problem

After merging PR #52, attempting to change models results in this error:

```
Error: sessionId is not defined
    at ClankieClient.handleMessage (clankie-client.ts:335:28)
```

## Root Cause

In PR #52, we added manual event broadcasting for `model_changed` and `thinking_level_changed` events:

```typescript
this.broadcastEvent(sessionId, {
  type: 'model_changed',
  model: model,
});
```

However, `sessionId` is not defined in the `executeCommand` method scope. The method signature is:

```typescript
private async executeCommand(session: AgentSession, command: RpcCommand)
```

It only receives `session` and `command`, not `sessionId`.

## Solution

Add `sessionId` as the first parameter to `executeCommand`:

```typescript
private async executeCommand(sessionId: string, session: AgentSession, command: RpcCommand)
```

And update the call site to pass it:

```typescript
const response = await this.executeCommand(sessionId, session, command);
```

## Changes

- Updated `executeCommand` method signature to include `sessionId` parameter
- Updated call site in `handleCommand` to pass `sessionId`

## Testing

After this fix:
1. Change model via dropdown
2. No error should appear in console
3. UI should update immediately with the new model
4. Console logs should show successful event broadcasting