### PR TITLE
feat(web-ui): add event-to-render testing infrastructure

### DIFF
--- a/web-ui/bun.lock
+++ b/web-ui/bun.lock
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@tanstack/eslint-config": "^0.3.0",
         "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.2.0",
         "@types/node": "^22.10.2",
         "@types/react": "^19.2.0",
@@ -48,6 +49,8 @@
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
+
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
 
@@ -505,6 +508,8 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
@@ -769,6 +774,8 @@
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
@@ -1025,6 +1032,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
@@ -1269,6 +1278,8 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@10.2.3", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -1415,6 +1426,8 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -1518,6 +1531,8 @@
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -1762,6 +1777,8 @@
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
 
     "@tanstack/start-plugin-core/srvx": ["srvx@0.11.7", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-p9qj9wkv/MqG1VoJpOsqXv1QcaVcYRk7ifsC6i3TEwDXFyugdhJN4J3KzQPZq2IJJ2ZCt7ASOB++85pEK38jRw=="],
+
+    "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@tanstack/eslint-config": "^0.3.0",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",

--- a/web-ui/src/components/__tests__/connection-status.test.tsx
+++ b/web-ui/src/components/__tests__/connection-status.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests for ConnectionStatus component — displays connection state from store.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ConnectionStatus } from '../connection-status'
+import { updateConnectionStatus } from '@/stores/connection'
+
+describe('ConnectionStatus', () => {
+  it('shows "Connected" badge when connected', () => {
+    updateConnectionStatus('connected')
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+  })
+
+  it('shows "Connecting..." badge when connecting', () => {
+    updateConnectionStatus('connecting')
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getByText('Connecting...')).toBeInTheDocument()
+  })
+
+  it('shows "Disconnected" badge when disconnected', () => {
+    updateConnectionStatus('disconnected')
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getByText('Disconnected')).toBeInTheDocument()
+  })
+
+  it('shows error message when status is error', () => {
+    updateConnectionStatus('error', 'Connection failed')
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getByText('Connection failed')).toBeInTheDocument()
+  })
+
+  it('shows "Connection error" when status is error but no specific message', () => {
+    updateConnectionStatus('error')
+
+    render(<ConnectionStatus />)
+
+    expect(screen.getByText('Connection error')).toBeInTheDocument()
+  })
+
+  it('shows spinner icon when connecting', () => {
+    updateConnectionStatus('connecting')
+
+    const { container } = render(<ConnectionStatus />)
+
+    // Look for animate-spin class
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('does not show spinner when connected', () => {
+    updateConnectionStatus('connected')
+
+    const { container } = render(<ConnectionStatus />)
+
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).not.toBeInTheDocument()
+  })
+})

--- a/web-ui/src/components/__tests__/message-bubble.test.tsx
+++ b/web-ui/src/components/__tests__/message-bubble.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for MessageBubble component — pure presentational component.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MessageBubble } from '../message-bubble'
+import { makeDisplayMessage } from '@/test/fixtures'
+
+describe('MessageBubble', () => {
+  describe('user messages', () => {
+    it('renders user message with correct content', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: 'Hello, how are you?',
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.getByText('Hello, how are you?')).toBeInTheDocument()
+    })
+
+    it('renders user icon', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: 'Test',
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // User icon SVG should be present
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('renders plain text for user messages (no markdown)', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: '**bold** text',
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // Should render literally, not as markdown
+      expect(screen.getByText('**bold** text')).toBeInTheDocument()
+      // No <strong> tag should exist
+      expect(container.querySelector('strong')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('assistant messages', () => {
+    it('renders assistant message with markdown', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'This is **bold** text',
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // Should have rendered markdown
+      const strong = container.querySelector('strong')
+      expect(strong).toBeInTheDocument()
+      expect(strong?.textContent).toBe('bold')
+    })
+
+    it('renders bot icon for assistant', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Test',
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // Bot icon SVG should be present
+      const svg = container.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+    })
+
+    it('shows "..." when content is empty', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: '',
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.getByText('...')).toBeInTheDocument()
+    })
+
+    it('shows streaming cursor when isStreaming is true', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Typing',
+        isStreaming: true,
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // Look for the cursor span with animate-pulse class
+      const cursor = container.querySelector('.animate-pulse')
+      expect(cursor).toBeInTheDocument()
+    })
+
+    it('does not show streaming cursor for user messages', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: 'Test',
+        isStreaming: true,
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      const cursor = container.querySelector('.animate-pulse')
+      expect(cursor).not.toBeInTheDocument()
+    })
+  })
+
+  describe('thinking content', () => {
+    it('shows thinking block when isThinking and has thinkingContent', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Final answer',
+        isThinking: true,
+        thinkingContent: 'Let me think about this...',
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.getByText('Thinking...')).toBeInTheDocument()
+      expect(screen.getByText('Let me think about this...')).toBeInTheDocument()
+    })
+
+    it('shows thinking block with spinner icon', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Answer',
+        isThinking: true,
+        thinkingContent: 'Processing...',
+      })
+
+      const { container } = render(<MessageBubble message={message} />)
+
+      // Look for the Loader2 icon with animate-spin
+      const spinner = container.querySelector('.animate-spin')
+      expect(spinner).toBeInTheDocument()
+    })
+
+    it('does not show thinking block when isThinking but no thinkingContent', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Answer',
+        isThinking: true,
+        thinkingContent: undefined,
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.queryByText('Thinking...')).not.toBeInTheDocument()
+    })
+
+    it('does not show thinking block when not isThinking', () => {
+      const message = makeDisplayMessage({
+        role: 'assistant',
+        content: 'Answer',
+        isThinking: false,
+        thinkingContent: 'Some content',
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.queryByText('Thinking...')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/web-ui/src/components/model-selector.tsx
+++ b/web-ui/src/components/model-selector.tsx
@@ -32,7 +32,11 @@ export function ModelSelector() {
       return
     }
 
-    console.log('[ModelSelector] Changing model:', { provider, modelId, sessionId })
+    console.log('[ModelSelector] Changing model:', {
+      provider,
+      modelId,
+      sessionId,
+    })
 
     const client = clientManager.getClient()
     if (client) {
@@ -109,8 +113,7 @@ export function ModelSelector() {
 
         <div className="max-h-96 overflow-y-auto">
           {availableModels.map((m) => {
-            const isActive =
-              model.provider === m.provider && model.id === m.id
+            const isActive = model.provider === m.provider && model.id === m.id
             return (
               <DropdownMenuItem
                 key={`${m.provider}/${m.id}`}

--- a/web-ui/src/lib/__tests__/event-handlers.test.ts
+++ b/web-ui/src/lib/__tests__/event-handlers.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for event-handlers.ts — the core event→store mapping logic.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { handleAuthEvent, handleSessionEvent } from '../event-handlers'
+import {
+  makeAgentEndEvent,
+  makeAgentStartEvent,
+  makeAuthCompleteEvent,
+  makeAuthProgressEvent,
+  makeAuthPromptEvent,
+  makeAuthUrlEvent,
+  makeCompactEndEvent,
+  makeCompactStartEvent,
+  makeMessageEndEvent,
+  makeMessageStartEvent,
+  makeMessageUpdateEvent,
+  makeModelChangedEvent,
+  makeModelInfo,
+  makeSessionStartEvent,
+  makeStateUpdateEvent,
+  makeThinkingEndEvent,
+  makeThinkingLevelChangedEvent,
+  makeThinkingStartEvent,
+} from '@/test/fixtures'
+import { resetAllStores } from '@/test/setup'
+import { authStore, startLoginFlow } from '@/stores/auth'
+import { messagesStore } from '@/stores/messages'
+import { sessionStore } from '@/stores/session'
+import { sessionsListStore, setActiveSession } from '@/stores/sessions-list'
+
+describe('handleSessionEvent', () => {
+  beforeEach(() => {
+    resetAllStores()
+  })
+
+  describe('agent lifecycle events', () => {
+    it('agent_start sets isStreaming to true (active session)', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent('session-1', makeAgentStartEvent(), 'session-1')
+
+      expect(sessionStore.state.isStreaming).toBe(true)
+    })
+
+    it('agent_start does nothing for inactive session', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent('session-2', makeAgentStartEvent(), 'session-1')
+
+      expect(sessionStore.state.isStreaming).toBe(false)
+    })
+
+    it('agent_end sets isStreaming to false (active session)', () => {
+      setActiveSession('session-1')
+      // First set streaming to true
+      handleSessionEvent('session-1', makeAgentStartEvent(), 'session-1')
+
+      handleSessionEvent('session-1', makeAgentEndEvent(), 'session-1')
+
+      expect(sessionStore.state.isStreaming).toBe(false)
+    })
+
+    it('agent_end does nothing for inactive session', () => {
+      setActiveSession('session-1')
+      handleSessionEvent('session-1', makeAgentStartEvent(), 'session-1')
+
+      handleSessionEvent('session-2', makeAgentEndEvent(), 'session-1')
+
+      expect(sessionStore.state.isStreaming).toBe(true)
+    })
+  })
+
+  describe('message streaming events', () => {
+    it('message_start creates a new assistant message (active session)', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-1',
+        makeMessageStartEvent('assistant'),
+        'session-1',
+      )
+
+      const messages = messagesStore.state.messages
+      expect(messages).toHaveLength(1)
+      expect(messages[0].role).toBe('assistant')
+      expect(messages[0].isStreaming).toBe(true)
+      expect(messagesStore.state.currentMessageId).toBeTruthy()
+    })
+
+    it('message_start does nothing for user messages', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-1',
+        makeMessageStartEvent('user'),
+        'session-1',
+      )
+
+      expect(messagesStore.state.messages).toHaveLength(0)
+    })
+
+    it('message_update with text_delta accumulates content', () => {
+      setActiveSession('session-1')
+      handleSessionEvent(
+        'session-1',
+        makeMessageStartEvent('assistant'),
+        'session-1',
+      )
+
+      handleSessionEvent(
+        'session-1',
+        makeMessageUpdateEvent('Hello', 'text_delta'),
+        'session-1',
+      )
+      handleSessionEvent(
+        'session-1',
+        makeMessageUpdateEvent('Hello world', 'text_delta'),
+        'session-1',
+      )
+
+      const messages = messagesStore.state.messages
+      expect(messages[0].content).toBe('Hello world')
+      expect(messages[0].isStreaming).toBe(true)
+    })
+
+    it('thinking lifecycle: start → delta → end', () => {
+      setActiveSession('session-1')
+      handleSessionEvent(
+        'session-1',
+        makeMessageStartEvent('assistant'),
+        'session-1',
+      )
+
+      // Start thinking
+      handleSessionEvent('session-1', makeThinkingStartEvent(), 'session-1')
+      expect(messagesStore.state.messages[0].isThinking).toBe(true)
+
+      // Delta thinking
+      handleSessionEvent(
+        'session-1',
+        makeMessageUpdateEvent('Thinking...', 'thinking_delta'),
+        'session-1',
+      )
+      expect(messagesStore.state.messages[0].thinkingContent).toBe(
+        'Thinking...',
+      )
+
+      // End thinking
+      handleSessionEvent('session-1', makeThinkingEndEvent(), 'session-1')
+      expect(messagesStore.state.messages[0].isThinking).toBe(false)
+    })
+
+    it('message_end for assistant clears streaming flags', () => {
+      setActiveSession('session-1')
+      handleSessionEvent(
+        'session-1',
+        makeMessageStartEvent('assistant'),
+        'session-1',
+      )
+      handleSessionEvent(
+        'session-1',
+        makeMessageUpdateEvent('Hello', 'text_delta'),
+        'session-1',
+      )
+
+      handleSessionEvent(
+        'session-1',
+        makeMessageEndEvent('assistant', 'Hello'),
+        'session-1',
+      )
+
+      expect(messagesStore.state.messages[0].isStreaming).toBe(false)
+      expect(messagesStore.state.currentMessageId).toBeNull()
+    })
+
+    it('message_end for user updates session title', () => {
+      const sessionId = 'session-1'
+      setActiveSession(sessionId)
+      handleSessionEvent(sessionId, makeSessionStartEvent(sessionId), sessionId)
+
+      handleSessionEvent(
+        sessionId,
+        makeMessageEndEvent('user', 'What is the weather?'),
+        sessionId,
+      )
+
+      const session = sessionsListStore.state.sessions.find(
+        (s) => s.sessionId === sessionId,
+      )
+      expect(session?.title).toBe('What is the weather?')
+    })
+
+    it('message_end truncates long user messages to 100 chars', () => {
+      const sessionId = 'session-1'
+      setActiveSession(sessionId)
+      handleSessionEvent(sessionId, makeSessionStartEvent(sessionId), sessionId)
+
+      const longMessage = 'a'.repeat(150)
+      handleSessionEvent(
+        sessionId,
+        makeMessageEndEvent('user', longMessage),
+        sessionId,
+      )
+
+      const session = sessionsListStore.state.sessions.find(
+        (s) => s.sessionId === sessionId,
+      )
+      expect(session?.title).toHaveLength(100)
+      expect(session?.title).toBe('a'.repeat(100))
+    })
+
+    it('message events do nothing for inactive session', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-2',
+        makeMessageStartEvent('assistant'),
+        'session-1',
+      )
+      handleSessionEvent(
+        'session-2',
+        makeMessageUpdateEvent('Hello', 'text_delta'),
+        'session-1',
+      )
+
+      expect(messagesStore.state.messages).toHaveLength(0)
+    })
+  })
+
+  describe('session events', () => {
+    it('session_start adds session to list', () => {
+      const sessionId = 'session-new'
+
+      handleSessionEvent(sessionId, makeSessionStartEvent(sessionId), null)
+
+      const sessions = sessionsListStore.state.sessions
+      expect(sessions).toHaveLength(1)
+      expect(sessions[0].sessionId).toBe(sessionId)
+      expect(sessions[0].messageCount).toBe(0)
+    })
+
+    it('session_start sets sessionId in store if active', () => {
+      const sessionId = 'session-new'
+
+      handleSessionEvent(sessionId, makeSessionStartEvent(sessionId), sessionId)
+
+      expect(sessionStore.state.sessionId).toBe(sessionId)
+    })
+
+    it('model_changed updates model (active session)', () => {
+      const newModel = makeModelInfo({ name: 'Claude 3 Opus', id: 'opus' })
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-1',
+        makeModelChangedEvent(newModel),
+        'session-1',
+      )
+
+      expect(sessionStore.state.model).toEqual(newModel)
+    })
+
+    it('model_changed ignores inactive session', () => {
+      const newModel = makeModelInfo({ name: 'Claude 3 Opus' })
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-2',
+        makeModelChangedEvent(newModel),
+        'session-1',
+      )
+
+      expect(sessionStore.state.model).toBeNull()
+    })
+
+    it('thinking_level_changed updates level (active session)', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-1',
+        makeThinkingLevelChangedEvent('extended'),
+        'session-1',
+      )
+
+      expect(sessionStore.state.thinkingLevel).toBe('extended')
+    })
+
+    it('thinking_level_changed ignores inactive session', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent(
+        'session-2',
+        makeThinkingLevelChangedEvent('extended'),
+        'session-1',
+      )
+
+      expect(sessionStore.state.thinkingLevel).toBe('normal') // default
+    })
+
+    it('state_update updates both session store and sessions list', () => {
+      const sessionId = 'session-1'
+      setActiveSession(sessionId)
+      handleSessionEvent(sessionId, makeSessionStartEvent(sessionId), sessionId)
+
+      handleSessionEvent(
+        sessionId,
+        makeStateUpdateEvent({ messageCount: 5, isStreaming: true }),
+        sessionId,
+      )
+
+      // Check session store
+      expect(sessionStore.state.messageCount).toBe(5)
+      expect(sessionStore.state.isStreaming).toBe(true)
+
+      // Check sessions list
+      const session = sessionsListStore.state.sessions[0]
+      expect(session.messageCount).toBe(5)
+    })
+
+    it('state_update only updates sessions list for inactive session', () => {
+      const sessionId = 'session-2'
+      setActiveSession('session-1')
+      handleSessionEvent(
+        sessionId,
+        makeSessionStartEvent(sessionId),
+        'session-1',
+      )
+
+      handleSessionEvent(
+        sessionId,
+        makeStateUpdateEvent({ messageCount: 10 }),
+        'session-1',
+      )
+
+      // Session store not updated
+      expect(sessionStore.state.messageCount).toBe(0)
+
+      // Sessions list updated
+      const session = sessionsListStore.state.sessions.find(
+        (s) => s.sessionId === sessionId,
+      )
+      expect(session?.messageCount).toBe(10)
+    })
+  })
+
+  describe('compaction events', () => {
+    it('compact_start sets isCompacting to true (active session)', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent('session-1', makeCompactStartEvent(), 'session-1')
+
+      expect(sessionStore.state.isCompacting).toBe(true)
+    })
+
+    it('compact_end sets isCompacting to false (active session)', () => {
+      setActiveSession('session-1')
+      handleSessionEvent('session-1', makeCompactStartEvent(), 'session-1')
+
+      handleSessionEvent('session-1', makeCompactEndEvent(), 'session-1')
+
+      expect(sessionStore.state.isCompacting).toBe(false)
+    })
+
+    it('compact events do nothing for inactive session', () => {
+      setActiveSession('session-1')
+
+      handleSessionEvent('session-2', makeCompactStartEvent(), 'session-1')
+
+      expect(sessionStore.state.isCompacting).toBe(false)
+    })
+  })
+
+  describe('RPC response events', () => {
+    it('response event is ignored (handled elsewhere)', () => {
+      const response = {
+        type: 'response' as const,
+        command: 'get_state',
+        success: true,
+        data: { foo: 'bar' },
+      }
+
+      // Should not throw
+      handleSessionEvent('session-1', response, 'session-1')
+
+      // Stores unchanged
+      expect(sessionStore.state.sessionId).toBeNull()
+    })
+  })
+})
+
+describe('handleAuthEvent', () => {
+  beforeEach(() => {
+    resetAllStores()
+  })
+
+  it('url event transitions to waiting_url status', () => {
+    const loginFlowId = 'flow-123'
+    startLoginFlow(loginFlowId, 'anthropic')
+
+    handleAuthEvent(
+      makeAuthUrlEvent(loginFlowId, 'https://oauth.anthropic.com'),
+    )
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('waiting_url')
+    expect(flow?.url).toBe('https://oauth.anthropic.com')
+    expect(flow?.instructions).toBe('Click the link to authenticate')
+  })
+
+  it('prompt event transitions to waiting_input status', () => {
+    const loginFlowId = 'flow-123'
+    startLoginFlow(loginFlowId, 'anthropic')
+
+    handleAuthEvent(makeAuthPromptEvent(loginFlowId, 'Enter your code'))
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('waiting_input')
+    expect(flow?.promptMessage).toBe('Enter your code')
+  })
+
+  it('progress event transitions to in_progress status', () => {
+    const loginFlowId = 'flow-123'
+    startLoginFlow(loginFlowId, 'anthropic')
+
+    handleAuthEvent(makeAuthProgressEvent(loginFlowId, 'Verifying...'))
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('in_progress')
+    expect(flow?.progressMessage).toBe('Verifying...')
+  })
+
+  it('complete event with success transitions to complete status', () => {
+    const loginFlowId = 'flow-123'
+    startLoginFlow(loginFlowId, 'anthropic')
+
+    handleAuthEvent(makeAuthCompleteEvent(loginFlowId, true))
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('complete')
+    expect(flow?.success).toBe(true)
+  })
+
+  it('complete event with error transitions to error status', () => {
+    const loginFlowId = 'flow-123'
+    startLoginFlow(loginFlowId, 'anthropic')
+
+    handleAuthEvent(makeAuthCompleteEvent(loginFlowId, false, 'Invalid token'))
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('error')
+    expect(flow?.success).toBe(false)
+    expect(flow?.error).toBe('Invalid token')
+  })
+
+  it('ignores events for wrong loginFlowId', () => {
+    startLoginFlow('flow-123', 'anthropic')
+
+    // Send event for different flow
+    handleAuthEvent(makeAuthUrlEvent('flow-456', 'https://example.com'))
+
+    const flow = authStore.state.loginFlow
+    expect(flow?.status).toBe('idle') // unchanged
+    expect(flow?.url).toBeUndefined()
+  })
+
+  it('handles event when no login flow is active', () => {
+    // Should not throw
+    handleAuthEvent(makeAuthUrlEvent('flow-123', 'https://example.com'))
+
+    expect(authStore.state.loginFlow).toBeNull()
+  })
+})

--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -3,27 +3,15 @@
  */
 
 import { ClankieClient } from './clankie-client'
-import type { AgentSessionEvent, AuthEvent, RpcResponse } from './types'
-import { updateLoginFlow } from '@/stores/auth'
+import { handleAuthEvent, handleSessionEvent } from './event-handlers'
 import { connectionStore, updateConnectionStatus } from '@/stores/connection'
-import {
-  appendStreamToken,
-  appendThinkingToken,
-  clearMessages,
-  endAssistantMessage,
-  endThinking,
-  setMessages,
-  startAssistantMessage,
-  startThinking,
-} from '@/stores/messages'
+import { clearMessages, setMessages } from '@/stores/messages'
 import {
   resetSession,
   setAvailableModels,
-  setCompacting,
   setModel,
   setSessionId,
   setSessionName,
-  setStreaming,
   setThinkingLevel,
   updateSessionState,
 } from '@/stores/session'
@@ -32,7 +20,6 @@ import {
   clearSessions,
   sessionsListStore,
   setActiveSession,
-  updateSessionMeta,
 } from '@/stores/sessions-list'
 
 class ClientManager {
@@ -54,8 +41,11 @@ class ClientManager {
     this.client = new ClankieClient({
       url: settings.url,
       authToken: settings.authToken,
-      onEvent: (sessionId, event) => this.handleEvent(sessionId, event),
-      onAuthEvent: (event) => this.handleAuthEvent(event),
+      onEvent: (sessionId, event) => {
+        const { activeSessionId } = sessionsListStore.state
+        handleSessionEvent(sessionId, event, activeSessionId)
+      },
+      onAuthEvent: (event) => handleAuthEvent(event),
       onStateChange: (state, error) => {
         updateConnectionStatus(state, error)
         // Restore or create session when connection is established
@@ -160,210 +150,6 @@ class ClientManager {
 
   isConnected(): boolean {
     return this.client?.getConnectionState() === 'connected'
-  }
-
-  private handleEvent(
-    sessionId: string,
-    event: AgentSessionEvent | RpcResponse,
-  ): void {
-    // Handle RPC responses (shouldn't normally reach here as they're handled by promises)
-    if (event.type === 'response') {
-      console.log('[client-manager] RPC response:', event)
-      return
-    }
-
-    console.log(
-      `[client-manager] Received event for session ${sessionId}:`,
-      event.type,
-      event,
-    )
-
-    const { activeSessionId } = sessionsListStore.state
-    const isActiveSession = sessionId === activeSessionId
-
-    if (event.type === 'model_changed' || event.type === 'thinking_level_changed') {
-      console.log('[client-manager] Event check:', {
-        eventType: event.type,
-        eventSessionId: sessionId,
-        activeSessionId,
-        isActiveSession,
-      })
-    }
-
-    // Handle agent session events (pi-agent-core event protocol)
-    switch (event.type) {
-      // ─── Session events ────────────────────────────────────────────────
-      case 'session_start':
-        // Add new session to the list
-        addSession({
-          sessionId,
-          title: undefined,
-          messageCount: 0,
-          createdAt: Date.now(),
-        })
-
-        // Set as active and update single-session store only if it's the active one
-        if (isActiveSession) {
-          setSessionId(sessionId)
-        }
-        break
-
-      case 'session_name_changed':
-        // Update single-session store only if active
-        if (isActiveSession) {
-          setSessionName(event.name)
-        }
-        break
-
-      case 'model_changed':
-        console.log('[client-manager] model_changed event:', {
-          sessionId,
-          isActiveSession,
-          model: event.model,
-        })
-        // Update single-session store only if active
-        if (isActiveSession) {
-          setModel(event.model)
-        }
-        break
-
-      case 'thinking_level_changed':
-        if (isActiveSession) {
-          setThinkingLevel(event.level)
-        }
-        break
-
-      case 'state_update':
-        // Update message count in session list
-        updateSessionMeta(sessionId, {
-          messageCount: event.state.messageCount,
-        })
-
-        if (isActiveSession) {
-          updateSessionState(event.state)
-        }
-        break
-
-      // ─── Agent lifecycle ───────────────────────────────────────────────
-      case 'agent_start':
-        if (isActiveSession) {
-          setStreaming(true)
-        }
-        break
-
-      case 'agent_end':
-        if (isActiveSession) {
-          setStreaming(false)
-        }
-        break
-
-      // ─── Message streaming ─────────────────────────────────────────────
-      case 'message_start':
-        if (isActiveSession && event.message?.role === 'assistant') {
-          startAssistantMessage()
-        }
-        break
-
-      case 'message_update': {
-        if (!isActiveSession) break
-
-        const ame = event.assistantMessageEvent
-
-        switch (ame.type) {
-          case 'text_delta':
-            // Use the accumulated text from the partial assistant message
-            appendStreamToken(
-              ame.partial?.content
-                ?.filter((c: any) => c.type === 'text')
-                .map((c: any) => c.text)
-                .join('') ?? '',
-            )
-            break
-
-          case 'thinking_start':
-            startThinking()
-            break
-
-          case 'thinking_delta':
-            appendThinkingToken(
-              ame.partial?.content
-                ?.filter((c: any) => c.type === 'thinking')
-                .map((c: any) => c.thinking)
-                .join('') ?? '',
-            )
-            break
-
-          case 'thinking_end':
-            endThinking()
-            break
-        }
-        break
-      }
-
-      case 'message_end':
-        if (isActiveSession) {
-          if (event.message?.role === 'assistant') {
-            endAssistantMessage()
-          } else if (event.message?.role === 'user') {
-            // Update session title with the latest user message
-            const textContent = event.message.content
-              ?.filter((c: any) => c.type === 'text')
-              .map((c: any) => c.text)
-              .join(' ')
-            if (textContent) {
-              const title = textContent.substring(0, 100)
-              updateSessionMeta(sessionId, { title })
-            }
-          }
-        }
-        break
-
-      // ─── Turn lifecycle ────────────────────────────────────────────────
-      case 'turn_start':
-      case 'turn_end':
-        break
-
-      // ─── Tool execution ────────────────────────────────────────────────
-      case 'tool_execution_start':
-        if (isActiveSession) {
-          console.log('[client-manager] Tool execution:', event.toolName)
-        }
-        break
-
-      case 'tool_execution_update':
-        break
-
-      case 'tool_execution_end':
-        break
-
-      // ─── Compaction ────────────────────────────────────────────────────
-      case 'compact_start':
-      case 'auto_compaction_start':
-        if (isActiveSession) {
-          setCompacting(true)
-        }
-        break
-
-      case 'compact_end':
-      case 'auto_compaction_end':
-        if (isActiveSession) {
-          setCompacting(false)
-        }
-        break
-
-      // ─── Errors ────────────────────────────────────────────────────────
-      case 'error':
-        console.error('[client-manager] Agent error:', event.error)
-        break
-
-      default:
-        console.log('[client-manager] Unhandled event:', event)
-    }
-  }
-
-  private handleAuthEvent(event: AuthEvent): void {
-    console.log('[client-manager] Auth event:', event)
-    updateLoginFlow(event)
   }
 
   // ─── Session management ────────────────────────────────────────────────────

--- a/web-ui/src/lib/event-handlers.ts
+++ b/web-ui/src/lib/event-handlers.ts
@@ -1,0 +1,246 @@
+/**
+ * Event handlers — pure functions that map WebSocket events to store actions.
+ * Extracted from ClientManager to enable testing.
+ */
+
+import type { AgentSessionEvent, AuthEvent, RpcResponse } from './types'
+import { updateLoginFlow } from '@/stores/auth'
+import {
+  appendStreamToken,
+  appendThinkingToken,
+  endAssistantMessage,
+  endThinking,
+  startAssistantMessage,
+  startThinking,
+} from '@/stores/messages'
+import {
+  setCompacting,
+  setModel,
+  setSessionId,
+  setSessionName,
+  setStreaming,
+  setThinkingLevel,
+  updateSessionState,
+} from '@/stores/session'
+import { addSession, updateSessionMeta } from '@/stores/sessions-list'
+
+/**
+ * Handle session-level agent events.
+ * Dispatches to the appropriate store actions based on event type.
+ *
+ * @param sessionId - The session this event belongs to
+ * @param event - The agent event
+ * @param activeSessionId - The currently active session (for filtering)
+ */
+export function handleSessionEvent(
+  sessionId: string,
+  event: AgentSessionEvent | RpcResponse,
+  activeSessionId: string | null,
+): void {
+  // Handle RPC responses (shouldn't normally reach here as they're handled by promises)
+  if (event.type === 'response') {
+    console.log('[event-handlers] RPC response:', event)
+    return
+  }
+
+  console.log(
+    `[event-handlers] Received event for session ${sessionId}:`,
+    event.type,
+    event,
+  )
+
+  const isActiveSession = sessionId === activeSessionId
+
+  if (
+    event.type === 'model_changed' ||
+    event.type === 'thinking_level_changed'
+  ) {
+    console.log('[event-handlers] Event check:', {
+      eventType: event.type,
+      eventSessionId: sessionId,
+      activeSessionId,
+      isActiveSession,
+    })
+  }
+
+  // Handle agent session events (pi-agent-core event protocol)
+  switch (event.type) {
+    // ─── Session events ────────────────────────────────────────────────
+    case 'session_start':
+      // Add new session to the list
+      addSession({
+        sessionId,
+        title: undefined,
+        messageCount: 0,
+        createdAt: Date.now(),
+      })
+
+      // Set as active and update single-session store only if it's the active one
+      if (isActiveSession) {
+        setSessionId(sessionId)
+      }
+      break
+
+    case 'session_name_changed':
+      // Update single-session store only if active
+      if (isActiveSession) {
+        setSessionName(event.name)
+      }
+      break
+
+    case 'model_changed':
+      console.log('[event-handlers] model_changed event:', {
+        sessionId,
+        isActiveSession,
+        model: event.model,
+      })
+      // Update single-session store only if active
+      if (isActiveSession) {
+        setModel(event.model)
+      }
+      break
+
+    case 'thinking_level_changed':
+      if (isActiveSession) {
+        setThinkingLevel(event.level)
+      }
+      break
+
+    case 'state_update':
+      // Update message count in session list
+      updateSessionMeta(sessionId, {
+        messageCount: event.state.messageCount,
+      })
+
+      if (isActiveSession) {
+        updateSessionState(event.state)
+      }
+      break
+
+    // ─── Agent lifecycle ───────────────────────────────────────────────
+    case 'agent_start':
+      if (isActiveSession) {
+        setStreaming(true)
+      }
+      break
+
+    case 'agent_end':
+      if (isActiveSession) {
+        setStreaming(false)
+      }
+      break
+
+    // ─── Message streaming ─────────────────────────────────────────────
+    case 'message_start':
+      if (isActiveSession && event.message?.role === 'assistant') {
+        startAssistantMessage()
+      }
+      break
+
+    case 'message_update': {
+      if (!isActiveSession) break
+
+      const ame = event.assistantMessageEvent
+
+      switch (ame.type) {
+        case 'text_delta':
+          // Use the accumulated text from the partial assistant message
+          appendStreamToken(
+            ame.partial?.content
+              ?.filter((c: any) => c.type === 'text')
+              .map((c: any) => c.text)
+              .join('') ?? '',
+          )
+          break
+
+        case 'thinking_start':
+          startThinking()
+          break
+
+        case 'thinking_delta':
+          appendThinkingToken(
+            ame.partial?.content
+              ?.filter((c: any) => c.type === 'thinking')
+              .map((c: any) => c.thinking)
+              .join('') ?? '',
+          )
+          break
+
+        case 'thinking_end':
+          endThinking()
+          break
+      }
+      break
+    }
+
+    case 'message_end':
+      if (isActiveSession) {
+        if (event.message?.role === 'assistant') {
+          endAssistantMessage()
+        } else if (event.message?.role === 'user') {
+          // Update session title with the latest user message
+          const textContent = event.message.content
+            ?.filter((c: any) => c.type === 'text')
+            .map((c: any) => c.text)
+            .join(' ')
+          if (textContent) {
+            const title = textContent.substring(0, 100)
+            updateSessionMeta(sessionId, { title })
+          }
+        }
+      }
+      break
+
+    // ─── Turn lifecycle ────────────────────────────────────────────────
+    case 'turn_start':
+    case 'turn_end':
+      break
+
+    // ─── Tool execution ────────────────────────────────────────────────
+    case 'tool_execution_start':
+      if (isActiveSession) {
+        console.log('[event-handlers] Tool execution:', event.toolName)
+      }
+      break
+
+    case 'tool_execution_update':
+      break
+
+    case 'tool_execution_end':
+      break
+
+    // ─── Compaction ────────────────────────────────────────────────────
+    case 'compact_start':
+    case 'auto_compaction_start':
+      if (isActiveSession) {
+        setCompacting(true)
+      }
+      break
+
+    case 'compact_end':
+    case 'auto_compaction_end':
+      if (isActiveSession) {
+        setCompacting(false)
+      }
+      break
+
+    // ─── Errors ────────────────────────────────────────────────────────
+    case 'error':
+      console.error('[event-handlers] Agent error:', event.error)
+      break
+
+    default:
+      console.log('[event-handlers] Unhandled event:', event)
+  }
+}
+
+/**
+ * Handle auth-related events.
+ * Updates the auth store's login flow state.
+ *
+ * @param event - The auth event
+ */
+export function handleAuthEvent(event: AuthEvent): void {
+  console.log('[event-handlers] Auth event:', event)
+  updateLoginFlow(event)
+}

--- a/web-ui/src/test/fixtures.ts
+++ b/web-ui/src/test/fixtures.ts
@@ -1,0 +1,262 @@
+/**
+ * Test data factories — helper functions to create test fixtures.
+ */
+
+import type {
+  AgentSessionEvent,
+  AuthEvent,
+  ModelInfo,
+  SessionState,
+  ThinkingLevel,
+} from '@/lib/types'
+import type { DisplayMessage } from '@/stores/messages'
+import type { SessionListItem } from '@/stores/sessions-list'
+
+// ─── Model fixtures ────────────────────────────────────────────────────────────
+
+export function makeModelInfo(overrides?: Partial<ModelInfo>): ModelInfo {
+  return {
+    provider: 'anthropic',
+    id: 'claude-3-5-sonnet-20241022',
+    name: 'Claude 3.5 Sonnet',
+    inputPrice: 3,
+    outputPrice: 15,
+    contextWindow: 200000,
+    supportsImages: true,
+    supportsPromptCache: true,
+    ...overrides,
+  }
+}
+
+// ─── Session state fixtures ────────────────────────────────────────────────────
+
+export function makeSessionState(
+  overrides?: Partial<SessionState>,
+): SessionState {
+  return {
+    model: makeModelInfo(),
+    thinkingLevel: 'normal' as ThinkingLevel,
+    isStreaming: false,
+    isCompacting: false,
+    steeringMode: 'one-at-a-time',
+    followUpMode: 'one-at-a-time',
+    sessionFile: '/tmp/session-abc123.json',
+    sessionId: 'session-abc123',
+    sessionName: undefined,
+    autoCompactionEnabled: false,
+    messageCount: 0,
+    pendingMessageCount: 0,
+    ...overrides,
+  }
+}
+
+export function makeSessionListItem(
+  overrides?: Partial<SessionListItem>,
+): SessionListItem {
+  return {
+    sessionId: 'session-abc123',
+    title: undefined,
+    messageCount: 0,
+    createdAt: Date.now(),
+    ...overrides,
+  }
+}
+
+// ─── Message fixtures ──────────────────────────────────────────────────────────
+
+export function makeDisplayMessage(
+  overrides?: Partial<DisplayMessage>,
+): DisplayMessage {
+  return {
+    id: `msg-${Date.now()}`,
+    role: 'assistant',
+    content: 'Hello, how can I help?',
+    timestamp: Date.now(),
+    ...overrides,
+  }
+}
+
+// ─── Agent event fixtures ──────────────────────────────────────────────────────
+
+export function makeAgentStartEvent(): AgentSessionEvent {
+  return { type: 'agent_start' }
+}
+
+export function makeAgentEndEvent(): AgentSessionEvent {
+  return { type: 'agent_end', messages: [] }
+}
+
+export function makeMessageStartEvent(
+  role: 'user' | 'assistant' = 'assistant',
+): AgentSessionEvent {
+  return {
+    type: 'message_start',
+    message: { role, content: [] },
+  }
+}
+
+export function makeMessageUpdateEvent(
+  partialContent: string,
+  eventType: 'text_delta' | 'thinking_delta' = 'text_delta',
+): AgentSessionEvent {
+  const contentType = eventType === 'text_delta' ? 'text' : 'thinking'
+  const contentKey = eventType === 'text_delta' ? 'text' : 'thinking'
+
+  return {
+    type: 'message_update',
+    message: { role: 'assistant', content: [] },
+    assistantMessageEvent: {
+      type: eventType,
+      contentIndex: 0,
+      delta: partialContent,
+      partial: {
+        content: [{ type: contentType, [contentKey]: partialContent }],
+      },
+    },
+  }
+}
+
+export function makeThinkingStartEvent(): AgentSessionEvent {
+  return {
+    type: 'message_update',
+    message: { role: 'assistant', content: [] },
+    assistantMessageEvent: {
+      type: 'thinking_start',
+      contentIndex: 0,
+      partial: { content: [] },
+    },
+  }
+}
+
+export function makeThinkingEndEvent(): AgentSessionEvent {
+  return {
+    type: 'message_update',
+    message: { role: 'assistant', content: [] },
+    assistantMessageEvent: {
+      type: 'thinking_end',
+      contentIndex: 0,
+      content: 'I thought about this...',
+      partial: { content: [] },
+    },
+  }
+}
+
+export function makeMessageEndEvent(
+  role: 'user' | 'assistant' = 'assistant',
+  textContent = 'Hello',
+): AgentSessionEvent {
+  return {
+    type: 'message_end',
+    message: {
+      role,
+      content: [{ type: 'text', text: textContent }],
+    },
+  }
+}
+
+export function makeModelChangedEvent(model?: ModelInfo): AgentSessionEvent {
+  return {
+    type: 'model_changed',
+    model: model || makeModelInfo(),
+  }
+}
+
+export function makeThinkingLevelChangedEvent(
+  level: ThinkingLevel = 'extended',
+): AgentSessionEvent {
+  return {
+    type: 'thinking_level_changed',
+    level,
+  }
+}
+
+export function makeSessionStartEvent(
+  sessionId = 'session-new',
+): AgentSessionEvent {
+  return {
+    type: 'session_start',
+    sessionId,
+  }
+}
+
+export function makeSessionNameChangedEvent(name: string): AgentSessionEvent {
+  return {
+    type: 'session_name_changed',
+    name,
+  }
+}
+
+export function makeStateUpdateEvent(
+  state?: Partial<SessionState>,
+): AgentSessionEvent {
+  return {
+    type: 'state_update',
+    state: makeSessionState(state),
+  }
+}
+
+export function makeCompactStartEvent(): AgentSessionEvent {
+  return { type: 'compact_start' }
+}
+
+export function makeCompactEndEvent(): AgentSessionEvent {
+  return {
+    type: 'compact_end',
+    originalCount: 10,
+    compactedCount: 5,
+  }
+}
+
+// ─── Auth event fixtures ───────────────────────────────────────────────────────
+
+export function makeAuthUrlEvent(
+  loginFlowId: string,
+  url = 'https://auth.example.com/oauth',
+): AuthEvent {
+  return {
+    type: 'auth_event',
+    loginFlowId,
+    event: 'url',
+    url,
+    instructions: 'Click the link to authenticate',
+  }
+}
+
+export function makeAuthPromptEvent(
+  loginFlowId: string,
+  message = 'Enter code',
+): AuthEvent {
+  return {
+    type: 'auth_event',
+    loginFlowId,
+    event: 'prompt',
+    message,
+    placeholder: 'Paste code here',
+  }
+}
+
+export function makeAuthProgressEvent(
+  loginFlowId: string,
+  message = 'Processing...',
+): AuthEvent {
+  return {
+    type: 'auth_event',
+    loginFlowId,
+    event: 'progress',
+    message,
+  }
+}
+
+export function makeAuthCompleteEvent(
+  loginFlowId: string,
+  success = true,
+  error?: string,
+): AuthEvent {
+  return {
+    type: 'auth_event',
+    loginFlowId,
+    event: 'complete',
+    success,
+    error,
+  }
+}

--- a/web-ui/src/test/setup.ts
+++ b/web-ui/src/test/setup.ts
@@ -1,0 +1,96 @@
+/**
+ * Test setup file — runs before each test suite.
+ * Configures jsdom environment, @testing-library cleanup, and store resets.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach, beforeEach } from 'vitest'
+
+// Import all stores
+import { authStore } from '@/stores/auth'
+import { connectionStore } from '@/stores/connection'
+import { extensionsStore } from '@/stores/extensions'
+import { messagesStore } from '@/stores/messages'
+import { sessionStore } from '@/stores/session'
+import { sessionsListStore } from '@/stores/sessions-list'
+
+// Cleanup after each test (unmount React components)
+afterEach(() => {
+  cleanup()
+})
+
+// Reset all stores to initial state before each test
+beforeEach(() => {
+  resetAllStores()
+  // Clear localStorage (only if available in environment)
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear()
+  }
+})
+
+/**
+ * Reset all stores to their initial states.
+ * Call this in beforeEach or when needed.
+ */
+export function resetAllStores(): void {
+  // Auth store
+  authStore.setState(() => ({
+    providers: [],
+    isLoadingProviders: false,
+    loginFlow: null,
+  }))
+
+  // Connection store
+  connectionStore.setState(() => ({
+    settings: {
+      url: 'ws://localhost:3100',
+      authToken: '',
+    },
+    status: 'disconnected',
+    error: undefined,
+  }))
+
+  // Extensions store
+  extensionsStore.setState(() => ({
+    extensions: [],
+    extensionErrors: [],
+    skills: [],
+    skillDiagnostics: [],
+    isLoading: false,
+    installStatus: {
+      isInstalling: false,
+      output: '',
+      exitCode: null,
+    },
+  }))
+
+  // Messages store
+  messagesStore.setState(() => ({
+    messages: [],
+    streamingContent: '',
+    thinkingContent: '',
+    currentMessageId: null,
+  }))
+
+  // Session store
+  sessionStore.setState(() => ({
+    sessionId: null,
+    model: null,
+    availableModels: [],
+    thinkingLevel: 'normal',
+    isStreaming: false,
+    isCompacting: false,
+    steeringMode: 'one-at-a-time',
+    followUpMode: 'one-at-a-time',
+    sessionName: undefined,
+    autoCompactionEnabled: false,
+    messageCount: 0,
+  }))
+
+  // Sessions list store
+  sessionsListStore.setState(() => ({
+    sessions: [],
+    activeSessionId: null,
+  }))
+}

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import viteTsConfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [
+    // Enable path aliases from tsconfig.json
+    viteTsConfigPaths({
+      projects: ['./tsconfig.json'],
+    }),
+  ],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary

Implements the testing strategy from issue #55, focusing on the **event → store → component** pipeline — the core contract of the web-ui.

## What Changed

### 1. Refactored for testability
- **Extracted event handlers** from  into standalone  module
  - Two pure functions:  and 
  - No behavior change, just extraction for testability
  -  now calls these functions instead of having private methods

### 2. Test infrastructure
- **vitest config** with jsdom environment and path alias support
- **Test setup** with store resets () and @testing-library cleanup
- **Test fixtures** for creating test data (models, events, messages, etc.)

### 3. Tests added (50 total)

#### Event handler tests (31)
- **Agent lifecycle**: `agent_start` / `agent_end` toggle streaming state
- **Message streaming**: full flow from `message_start` → `text_delta` → `message_end`
- **Thinking flow**: `thinking_start` → `thinking_delta` → `thinking_end`
- **Session events**: `session_start`, `model_changed`, `thinking_level_changed`, `state_update`
- **Compaction events**: `compact_start` / `compact_end`
- **Active session gating**: events for inactive sessions are filtered correctly
- **Auth events**: OAuth flow state machine (`url` → `prompt` → `progress` → `complete`)

#### Component rendering tests (19)
- **MessageBubble** (12 tests)
  - User vs assistant styling
  - Markdown rendering for assistant messages
  - Streaming cursor display
  - Thinking block display
- **ConnectionStatus** (7 tests)
  - Badge states for connected/connecting/disconnected/error
  - Spinner animation during connecting
  - Error message display

## Test Coverage

- ✅ Event → store mapping (the critical path)
- ✅ Store → component rendering
- ✅ Active session filtering logic
- ✅ Auth flow state machine
- ✅ Message streaming lifecycle

## Files Changed

- **New**:
  - `web-ui/vitest.config.ts`
  - `web-ui/src/test/setup.ts`
  - `web-ui/src/test/fixtures.ts`
  - `web-ui/src/lib/event-handlers.ts`
  - `web-ui/src/lib/__tests__/event-handlers.test.ts`
  - `web-ui/src/components/__tests__/message-bubble.test.tsx`
  - `web-ui/src/components/__tests__/connection-status.test.tsx`
  
- **Modified**:
  - `web-ui/src/lib/client-manager.ts` (simplified, uses extracted handlers)
  - `web-ui/package.json` (added @testing-library/jest-dom)

## Run Tests

```bash
cd web-ui
bun test           # or: bunx vitest run
```

## Next Steps

This PR establishes the testing foundation. Follow-up work could include:
- More component tests (ChatMessages, SessionSidebar, ModelSelector, etc.)
- Integration tests for full event sequences
- WebSocket client unit tests

Resolves #55