### PR TITLE
Fix: WebSocket reconnection loses session event subscribers

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -373,6 +373,8 @@ export class WebChannel implements Channel {
 					return;
 				}
 			} else {
+				// Ensure this ws is subscribed (handles reconnection with new ws)
+				this.subscribeToSessionWithKey(sessionId, session, ws);
 				console.log(
 					`[web] Using cached session - chatKey: ${sessionId}, session.sessionId: ${session.sessionId}, sessionFile: ${session.sessionFile}`,
 				);


### PR DESCRIPTION
## Problem

After a WebSocket disconnection and reconnect, the chat breaks. Server logs:

```
[web] No subscribers for session web_1318d0f8-4958-495b-820f-99a1bc7869f3, event message_update
```

The client can send commands (prompts work), but never receives streaming events back (no assistant responses appear).

## Root Cause

In `src/channels/web.ts` `handleCommand()`, when a reconnected client sends commands for an existing session:

1. `handleClose()` correctly removes the old `ws` from `sessionSubscriptions`
2. On reconnect, a **new** `ws` object is created
3. `handleCommand()` finds the session in `this.sessions` cache and enters the `else` branch
4. The `else` branch **never adds the new `ws` to `sessionSubscriptions`**

## Solution

Call `subscribeToSessionWithKey()` in the `else` branch to ensure the new `ws` is added to subscribers. The method is already idempotent:
- Uses `Set.add()` which is idempotent (no duplicate ws entries)
- Checks `sessionUnsubscribers.has()` before creating a new event listener
- Sets `this.sessions` which is also idempotent

## Changes

- **1 line added** in `src/channels/web.ts` to call `subscribeToSessionWithKey()` when using a cached session

## Testing

- [x] Code compiles cleanly (no new lint errors)
- [ ] Manual test: disconnect/reconnect and verify events stream correctly

Closes #57