### PR TITLE
feat: auto-generate auth token during `clankie init` for seamless onboarding

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -258,6 +258,7 @@ export class WebChannel implements Channel {
 		});
 
 		console.log(`[web] WebSocket server listening on port ${this.options.port}`);
+		console.log(`[web] Open in browser: http://localhost:${this.options.port}?token=${this.options.authToken}`);
 	}
 
 	async send(_chatId: string, _text: string, _options?: { threadId?: string }): Promise<void> {


### PR DESCRIPTION
Implements a streamlined onboarding flow for connecting clankie's web-ui to the daemon.

## Changes

### 1. Add `clankie init` command (`src/cli.ts`)
- Generates a cryptographically secure auth token (32 bytes, base64url-encoded)
- Checks for existing token and prompts to regenerate or keep
- Saves web channel defaults to config:
  - `channels.web.authToken`: the generated token
  - `channels.web.port`: 3100 (default)
  - `channels.web.enabled`: true
- Prints a summary with next steps (`clankie login`, `clankie start`)
- Updates help text and examples

### 2. Print connect URL on daemon start (`src/channels/web.ts`)
- After the WebSocket server starts, logs:
  ```
  [web] Open in browser: http://localhost:{port}?token={authToken}
  ```
- Gives users a clickable URL with the token embedded

### 3. Frontend auto-detects token (`web-ui/src/routes/__root.tsx`)
- On page load, checks for `?token=` query parameter
- If found:
  - Saves token to `connectionStore` (persists to localStorage)
  - Strips token from URL using `window.history.replaceState`
- Existing auto-connect logic then kicks in automatically

## New Workflow

```bash
# Before (5+ steps, manual copy-paste)
clankie config set channels.web.authToken "my-secret-token"
clankie start
# Open web-ui, navigate to Settings, paste token, click Connect

# After (3 steps, zero copy-paste)
clankie init     # generates token, configures web channel
clankie login    # authenticate with AI provider
clankie start    # prints connect URL, click to open
```

## Testing

- [x] Run `clankie init`, verify token saved to `~/.clankie/clankie.json`
- [x] Run `clankie start`, verify connect URL is printed
- [x] Open the URL, verify token is auto-detected and stripped from address bar
- [x] Verify auto-connect works
- [x] Re-running `clankie init` prompts before overwriting existing token

## Closes #66