### PR TITLE
feat: bundle web-ui in npm package for zero-config deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+web-ui-dist/
 *.log
 .DS_Store
 .env

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tasks.publish]
-description = "Bump version and publish to npm"
+description = "Bump version and publish to npm (includes bundled web-ui)"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
@@ -18,6 +18,11 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
+# Build web-ui and copy to web-ui-dist/
+echo "==> Building web-ui…"
+bun run build:web-ui
+echo "==> Web-ui bundled into web-ui-dist/"
+
 # Bump version (updates package.json and creates git tag)
 NEW_VERSION=$(npm version "$BUMP" --no-git-tag-version)
 echo "Bumped to $NEW_VERSION"
@@ -27,13 +32,16 @@ git add package.json
 git commit -m "release: $NEW_VERSION"
 git tag "$NEW_VERSION"
 
-# Publish to npm
+# Publish to npm (web-ui-dist/ is included via "files" in package.json)
 npm publish --access public
+
+# Cleanup build artifact
+rm -rf web-ui-dist
 
 # Push commit and tag
 git push && git push --tags
 
-echo "✓ Published $NEW_VERSION"
+echo "✓ Published $NEW_VERSION (with bundled web-ui)"
 """
 
 [tasks.release-web-ui]

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
 	"bin": {
 		"clankie": "./src/cli.ts"
 	},
+	"files": ["src/", "web-ui-dist/", "package.json", "README.md"],
 	"scripts": {
 		"dev": "bun run src/cli.ts",
+		"build:web-ui": "cd web-ui && bun install --frozen-lockfile && bun run build && cd .. && rm -rf web-ui-dist && cp -r web-ui/.output/public web-ui-dist",
 		"check": "biome check .",
 		"check:fix": "biome check --fix .",
 		"format": "biome format --write ."

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,21 @@ export function getConfigPath(): string {
 	return CONFIG_PATH;
 }
 
+/**
+ * Resolve the path to the bundled web-ui static files.
+ * When installed via npm, these live at <package>/web-ui-dist/ alongside src/.
+ * Returns the path if found, undefined otherwise.
+ */
+export function getBundledWebUiDir(): string | undefined {
+	// import.meta.dir → <package>/src/ at runtime
+	const packageRoot = join(import.meta.dir, "..");
+	const bundledDir = join(packageRoot, "web-ui-dist");
+	if (existsSync(bundledDir) && existsSync(join(bundledDir, "_shell.html"))) {
+		return bundledDir;
+	}
+	return undefined;
+}
+
 // ─── Loading & saving ─────────────────────────────────────────────────────────
 
 /** Load config from ~/.clankie/clankie.json (JSON5). Returns empty config if missing. */

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import type { Channel, InboundMessage } from "./channels/channel.ts";
 import { SlackChannel } from "./channels/slack.ts";
 import { WebChannel } from "./channels/web.ts";
-import { getAppDir, getConfigPath, getWorkspace, loadConfig } from "./config.ts";
+import { getAppDir, getBundledWebUiDir, getConfigPath, getWorkspace, loadConfig } from "./config.ts";
 import {
 	getActiveSessionName,
 	getOrCreateSession,
@@ -243,12 +243,18 @@ async function initializeChannels(): Promise<void> {
 	// Web
 	const web = config.channels?.web;
 	if (web?.authToken && web.enabled !== false) {
+		// Resolve static dir: explicit config > bundled web-ui > none
+		const staticDir = web.staticDir ?? getBundledWebUiDir();
+		if (staticDir) {
+			console.log(`[daemon] Serving web-ui from: ${staticDir}`);
+		}
+
 		channels.push(
 			new WebChannel({
 				port: web.port ?? 3100,
 				authToken: web.authToken,
 				allowedOrigins: web.allowedOrigins,
-				staticDir: web.staticDir,
+				staticDir,
 			}),
 		);
 	}


### PR DESCRIPTION
## Summary

Bundle the built web-ui static files in the npm package so `clankie start` automatically serves the web-ui with zero extra configuration.

## How it works

1. **Build time** (`mise run publish`): builds the web-ui and copies `.output/public/` → `web-ui-dist/`
2. **npm publish**: includes `web-ui-dist/` in the package (~522kB gzipped)
3. **Runtime**: daemon auto-discovers bundled web-ui via `import.meta.dir` (resolves `<package>/web-ui-dist/`)
4. **Fallback chain**: explicit `staticDir` config → bundled web-ui → none

## Changes

- **`package.json`** — added `files` field and `build:web-ui` script
- **`src/config.ts`** — added `getBundledWebUiDir()` helper
- **`src/daemon.ts`** — auto-discover bundled web-ui when `staticDir` not set
- **`mise.toml`** — publish task now builds web-ui first
- **`.gitignore`** — ignore `web-ui-dist/` (build artifact)

## Deployment (after this)

```bash
# Install clankie (web-ui included!)
bun install -g clankie

# Configure and start
clankie config set channels.web.authToken "your-token"
clankie start
# → web-ui served at http://localhost:3100
```

No need to set `staticDir` — the bundled web-ui is found automatically.