### PR TITLE
feat(web-ui): Extract event handlers from ClientManager for testability

### DIFF
--- a/web-ui/src/lib/__tests__/event-handlers.test.ts
+++ b/web-ui/src/lib/__tests__/event-handlers.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	makeAgentEndEvent,
+	makeAgentStartEvent,
+	makeAuthEventComplete,
+	makeAuthEventPrompt,
+	makeAuthEventUrl,
+	makeCompactEndEvent,
+	makeCompactStartEvent,
+	makeMessageEndEvent,
+	makeMessageStartEvent,
+	makeModelChangedEvent,
+	makeModelInfo,
+	makeSessionNameChangedEvent,
+	makeSessionStartEvent,
+	makeSessionState,
+	makeStateUpdateEvent,
+	makeThinkingLevelChangedEvent,
+} from "@/test/fixtures";
+import { handleAuthEvent, handleSessionEvent } from "../event-handlers";
+import { authStore } from "@/stores/auth";
+import { messagesStore } from "@/stores/messages";
+import { sessionStore } from "@/stores/session";
+import { sessionsListStore } from "@/stores/sessions-list";
+
+describe("event-handlers", () => {
+	describe("handleSessionEvent", () => {
+		describe("session lifecycle events", () => {
+			it("session_start adds session to list", () => {
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), null);
+
+				const { sessions } = sessionsListStore.state;
+				expect(sessions).toHaveLength(1);
+				expect(sessions[0]).toMatchObject({
+					sessionId: "session-1",
+					title: undefined,
+					messageCount: 0,
+				});
+			});
+
+			it("session_start sets sessionId in session store if active", () => {
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), "session-1");
+
+				expect(sessionStore.state.sessionId).toBe("session-1");
+			});
+
+			it("session_start does not set sessionId if not active", () => {
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), "session-2");
+
+				expect(sessionStore.state.sessionId).toBeNull();
+			});
+
+			it("session_name_changed updates session store if active", () => {
+				handleSessionEvent("session-1", makeSessionNameChangedEvent("My Session"), "session-1");
+
+				expect(sessionStore.state.sessionName).toBe("My Session");
+			});
+
+			it("session_name_changed does nothing if not active", () => {
+				handleSessionEvent("session-1", makeSessionNameChangedEvent("My Session"), "session-2");
+
+				expect(sessionStore.state.sessionName).toBeUndefined();
+			});
+
+			it("model_changed updates model if active", () => {
+				const model = makeModelInfo({ name: "Claude 3.5 Sonnet" });
+				handleSessionEvent("session-1", makeModelChangedEvent(model), "session-1");
+
+				expect(sessionStore.state.model).toEqual(model);
+			});
+
+			it("model_changed does nothing if not active", () => {
+				const model = makeModelInfo({ name: "Claude 3.5 Sonnet" });
+				handleSessionEvent("session-1", makeModelChangedEvent(model), "session-2");
+
+				expect(sessionStore.state.model).toBeNull();
+			});
+
+			it("thinking_level_changed updates level if active", () => {
+				handleSessionEvent("session-1", makeThinkingLevelChangedEvent("high"), "session-1");
+
+				expect(sessionStore.state.thinkingLevel).toBe("high");
+			});
+
+			it("thinking_level_changed does nothing if not active", () => {
+				handleSessionEvent("session-1", makeThinkingLevelChangedEvent("high"), "session-2");
+
+				expect(sessionStore.state.thinkingLevel).toBe("medium"); // default
+			});
+
+			it("state_update updates message count in sessions list", () => {
+				// First add the session
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), null);
+
+				const state = makeSessionState({ messageCount: 10 });
+				handleSessionEvent("session-1", makeStateUpdateEvent(state), "session-1");
+
+				const { sessions } = sessionsListStore.state;
+				expect(sessions[0].messageCount).toBe(10);
+			});
+
+			it("state_update updates session store if active", () => {
+				const state = makeSessionState({ thinkingLevel: "xhigh", messageCount: 5 });
+				handleSessionEvent("session-1", makeStateUpdateEvent(state), "session-1");
+
+				expect(sessionStore.state).toMatchObject({
+					thinkingLevel: "xhigh",
+					messageCount: 5,
+				});
+			});
+
+			it("state_update does not update session store if not active", () => {
+				const state = makeSessionState({ thinkingLevel: "xhigh" });
+				handleSessionEvent("session-1", makeStateUpdateEvent(state), "session-2");
+
+				expect(sessionStore.state.thinkingLevel).toBe("medium"); // default
+			});
+		});
+
+		describe("agent lifecycle events", () => {
+			it("agent_start sets isStreaming to true if active", () => {
+				handleSessionEvent("session-1", makeAgentStartEvent(), "session-1");
+
+				expect(sessionStore.state.isStreaming).toBe(true);
+			});
+
+			it("agent_start does nothing if not active", () => {
+				handleSessionEvent("session-1", makeAgentStartEvent(), "session-2");
+
+				expect(sessionStore.state.isStreaming).toBe(false);
+			});
+
+			it("agent_end sets isStreaming to false if active", () => {
+				// First set streaming
+				handleSessionEvent("session-1", makeAgentStartEvent(), "session-1");
+				handleSessionEvent("session-1", makeAgentEndEvent(), "session-1");
+
+				expect(sessionStore.state.isStreaming).toBe(false);
+			});
+
+			it("agent_end does nothing if not active", () => {
+				handleSessionEvent("session-1", makeAgentStartEvent(), "session-1");
+				handleSessionEvent("session-1", makeAgentEndEvent(), "session-2");
+
+				expect(sessionStore.state.isStreaming).toBe(true); // Still true
+			});
+		});
+
+		describe("message streaming events", () => {
+			it("message_start creates assistant message if active", () => {
+				const message = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(message), "session-1");
+
+				const { messages } = messagesStore.state;
+				expect(messages).toHaveLength(1);
+				expect(messages[0].role).toBe("assistant");
+			});
+
+			it("message_start does nothing for user messages", () => {
+				const message = { role: "user" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(message), "session-1");
+
+				const { messages } = messagesStore.state;
+				expect(messages).toHaveLength(0);
+			});
+
+			it("message_start does nothing if not active", () => {
+				const message = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(message), "session-2");
+
+				const { messages } = messagesStore.state;
+				expect(messages).toHaveLength(0);
+			});
+
+			it("message_update with text_delta appends content if active", () => {
+				// Start a message first
+				const startMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(startMsg), "session-1");
+
+				// Send text_delta
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "text_delta",
+							contentIndex: 0,
+							delta: "Hello",
+							partial: {
+								content: [{ type: "text", text: "Hello world" }],
+							},
+						},
+					},
+					"session-1",
+				);
+
+				const { messages } = messagesStore.state;
+				expect(messages[0].content).toBe("Hello world");
+			});
+
+			it("message_update with thinking_start/delta/end updates thinking state if active", () => {
+				// Start a message
+				const startMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(startMsg), "session-1");
+
+				// thinking_start
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "thinking_start",
+							contentIndex: 0,
+							partial: {},
+						},
+					},
+					"session-1",
+				);
+
+				let { messages } = messagesStore.state;
+				expect(messages[0].isThinking).toBe(true);
+
+				// thinking_delta
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "thinking_delta",
+							contentIndex: 0,
+							delta: "Hmm",
+							partial: {
+								content: [{ type: "thinking", thinking: "Hmm, let me think" }],
+							},
+						},
+					},
+					"session-1",
+				);
+
+				messages = messagesStore.state.messages;
+				expect(messages[0].thinkingContent).toBe("Hmm, let me think");
+
+				// thinking_end
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "thinking_end",
+							contentIndex: 0,
+							content: "Done thinking",
+							partial: {},
+						},
+					},
+					"session-1",
+				);
+
+				messages = messagesStore.state.messages;
+				expect(messages[0].isThinking).toBe(false);
+			});
+
+			it("message_update does nothing if not active", () => {
+				// Start a message on session-1
+				const startMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(startMsg), "session-1");
+
+				// Send update for session-1 but session-2 is active
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "text_delta",
+							contentIndex: 0,
+							delta: "Hello",
+							partial: {
+								content: [{ type: "text", text: "Hello world" }],
+							},
+						},
+					},
+					"session-2",
+				);
+
+				const { messages } = messagesStore.state;
+				expect(messages[0].content).toBe(""); // Not updated
+			});
+
+			it("message_end for assistant ends streaming if active", () => {
+				// Start and stream a message
+				const startMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(startMsg), "session-1");
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "message_update",
+						message: startMsg,
+						assistantMessageEvent: {
+							type: "text_delta",
+							contentIndex: 0,
+							delta: "Done",
+							partial: { content: [{ type: "text", text: "Done" }] },
+						},
+					},
+					"session-1",
+				);
+
+				const endMsg = { role: "assistant" as const, content: [{ type: "text", text: "Done" }] };
+				handleSessionEvent("session-1", makeMessageEndEvent(endMsg), "session-1");
+
+				const { messages } = messagesStore.state;
+				expect(messages[0].isStreaming).toBe(false);
+			});
+
+			it("message_end for user updates session title if active", () => {
+				// Add session first
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), "session-1");
+
+				const userMsg = {
+					role: "user" as const,
+					content: [{ type: "text", text: "What is the meaning of life?" }],
+				};
+				handleSessionEvent("session-1", makeMessageEndEvent(userMsg), "session-1");
+
+				const { sessions } = sessionsListStore.state;
+				expect(sessions[0].title).toBe("What is the meaning of life?");
+			});
+
+			it("message_end for user truncates title to 100 chars", () => {
+				// Add session first
+				handleSessionEvent("session-1", makeSessionStartEvent("session-1"), "session-1");
+
+				const longText = "a".repeat(150);
+				const userMsg = {
+					role: "user" as const,
+					content: [{ type: "text", text: longText }],
+				};
+				handleSessionEvent("session-1", makeMessageEndEvent(userMsg), "session-1");
+
+				const { sessions } = sessionsListStore.state;
+				expect(sessions[0].title).toBe("a".repeat(100));
+			});
+
+			it("message_end does nothing if not active", () => {
+				// Start a message
+				const startMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageStartEvent(startMsg), "session-1");
+
+				// End message on different session
+				const endMsg = { role: "assistant" as const, content: [] };
+				handleSessionEvent("session-1", makeMessageEndEvent(endMsg), "session-2");
+
+				const { messages } = messagesStore.state;
+				expect(messages[0].isStreaming).toBe(true); // Still streaming
+			});
+		});
+
+		describe("compaction events", () => {
+			it("compact_start sets isCompacting to true if active", () => {
+				handleSessionEvent("session-1", makeCompactStartEvent(), "session-1");
+
+				expect(sessionStore.state.isCompacting).toBe(true);
+			});
+
+			it("auto_compaction_start sets isCompacting to true if active", () => {
+				handleSessionEvent(
+					"session-1",
+					{ type: "auto_compaction_start", reason: "too many messages" },
+					"session-1",
+				);
+
+				expect(sessionStore.state.isCompacting).toBe(true);
+			});
+
+			it("compact_end sets isCompacting to false if active", () => {
+				handleSessionEvent("session-1", makeCompactStartEvent(), "session-1");
+				handleSessionEvent("session-1", makeCompactEndEvent(100, 50), "session-1");
+
+				expect(sessionStore.state.isCompacting).toBe(false);
+			});
+
+			it("auto_compaction_end sets isCompacting to false if active", () => {
+				handleSessionEvent(
+					"session-1",
+					{ type: "auto_compaction_start", reason: "too many messages" },
+					"session-1",
+				);
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "auto_compaction_end",
+						result: {},
+						aborted: false,
+						willRetry: false,
+					},
+					"session-1",
+				);
+
+				expect(sessionStore.state.isCompacting).toBe(false);
+			});
+
+			it("compaction events do nothing if not active", () => {
+				handleSessionEvent("session-1", makeCompactStartEvent(), "session-2");
+
+				expect(sessionStore.state.isCompacting).toBe(false);
+			});
+		});
+
+		describe("RPC response events", () => {
+			it("response events are logged and ignored", () => {
+				const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "response",
+						command: "test",
+						success: true,
+						data: {},
+					},
+					"session-1",
+				);
+
+				expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("RPC response"), expect.any(Object));
+
+				// No store changes
+				expect(sessionStore.state.sessionId).toBeNull();
+
+				consoleSpy.mockRestore();
+			});
+		});
+
+		describe("unhandled events", () => {
+			it("turn_start and turn_end do nothing", () => {
+				handleSessionEvent("session-1", { type: "turn_start" }, "session-1");
+				handleSessionEvent("session-1", { type: "turn_end", message: {}, toolResults: [] }, "session-1");
+
+				// No errors, no state changes
+				expect(sessionStore.state.sessionId).toBeNull();
+			});
+
+			it("tool_execution events are logged if active", () => {
+				const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+				handleSessionEvent(
+					"session-1",
+					{
+						type: "tool_execution_start",
+						toolCallId: "1",
+						toolName: "bash",
+						args: {},
+					},
+					"session-1",
+				);
+
+				expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Tool execution"), "bash");
+
+				consoleSpy.mockRestore();
+			});
+
+			it("error events are logged", () => {
+				const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+				handleSessionEvent("session-1", { type: "error", error: "Something went wrong" }, "session-1");
+
+				expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Agent error"), "Something went wrong");
+
+				consoleSpy.mockRestore();
+			});
+		});
+	});
+
+	describe("handleAuthEvent", () => {
+		it("url event updates login flow", () => {
+			// Start a login flow first
+			authStore.setState(() => ({
+				providers: [],
+				isLoadingProviders: false,
+				loginFlow: {
+					loginFlowId: "flow-1",
+					providerId: "anthropic",
+					status: "idle",
+				},
+			}));
+
+			handleAuthEvent(makeAuthEventUrl("flow-1", "https://auth.example.com", "Sign in"));
+
+			expect(authStore.state.loginFlow).toMatchObject({
+				status: "waiting_url",
+				url: "https://auth.example.com",
+				instructions: "Sign in",
+			});
+		});
+
+		it("prompt event updates login flow", () => {
+			authStore.setState(() => ({
+				providers: [],
+				isLoadingProviders: false,
+				loginFlow: {
+					loginFlowId: "flow-1",
+					providerId: "anthropic",
+					status: "idle",
+				},
+			}));
+
+			handleAuthEvent(makeAuthEventPrompt("flow-1", "Enter code", "Code"));
+
+			expect(authStore.state.loginFlow).toMatchObject({
+				status: "waiting_input",
+				promptMessage: "Enter code",
+				promptPlaceholder: "Code",
+			});
+		});
+
+		it("complete event updates login flow", () => {
+			authStore.setState(() => ({
+				providers: [],
+				isLoadingProviders: false,
+				loginFlow: {
+					loginFlowId: "flow-1",
+					providerId: "anthropic",
+					status: "in_progress",
+				},
+			}));
+
+			handleAuthEvent(makeAuthEventComplete("flow-1", true));
+
+			expect(authStore.state.loginFlow).toMatchObject({
+				status: "complete",
+				success: true,
+			});
+		});
+
+		it("ignores events for wrong loginFlowId", () => {
+			authStore.setState(() => ({
+				providers: [],
+				isLoadingProviders: false,
+				loginFlow: {
+					loginFlowId: "flow-1",
+					providerId: "anthropic",
+					status: "idle",
+				},
+			}));
+
+			const initialFlow = authStore.state.loginFlow;
+			handleAuthEvent(makeAuthEventUrl("flow-2", "https://wrong.com"));
+
+			expect(authStore.state.loginFlow).toEqual(initialFlow);
+		});
+	});
+});

--- a/web-ui/src/lib/event-handlers.ts
+++ b/web-ui/src/lib/event-handlers.ts
@@ -1,0 +1,233 @@
+/**
+ * Event handlers — pure functions that map WebSocket events to store actions.
+ * Extracted from ClientManager for testability.
+ */
+
+import type { AgentSessionEvent, AuthEvent, RpcResponse } from "@/lib/types";
+import { updateLoginFlow } from "@/stores/auth";
+import {
+	appendStreamToken,
+	appendThinkingToken,
+	endAssistantMessage,
+	endThinking,
+	startAssistantMessage,
+	startThinking,
+} from "@/stores/messages";
+import {
+	setCompacting,
+	setModel,
+	setSessionId,
+	setSessionName,
+	setStreaming,
+	setThinkingLevel,
+	updateSessionState,
+} from "@/stores/session";
+import { addSession, updateSessionMeta } from "@/stores/sessions-list";
+
+/**
+ * Handle session events from the WebSocket.
+ * Dispatches to appropriate store actions based on event type and active session.
+ */
+export function handleSessionEvent(
+	sessionId: string,
+	event: AgentSessionEvent | RpcResponse,
+	activeSessionId: string | null,
+): void {
+	// Handle RPC responses (shouldn't normally reach here as they're handled by promises)
+	if (event.type === "response") {
+		console.log("[event-handlers] RPC response:", event);
+		return;
+	}
+
+	console.log(`[event-handlers] Received event for session ${sessionId}:`, event.type, event);
+
+	const isActiveSession = sessionId === activeSessionId;
+
+	if (event.type === "model_changed" || event.type === "thinking_level_changed") {
+		console.log("[event-handlers] Event check:", {
+			eventType: event.type,
+			eventSessionId: sessionId,
+			activeSessionId,
+			isActiveSession,
+		});
+	}
+
+	// Handle agent session events (pi-agent-core event protocol)
+	switch (event.type) {
+		// ─── Session events ────────────────────────────────────────────────
+		case "session_start":
+			// Add new session to the list
+			addSession({
+				sessionId,
+				title: undefined,
+				messageCount: 0,
+				createdAt: Date.now(),
+			});
+
+			// Set as active and update single-session store only if it's the active one
+			if (isActiveSession) {
+				setSessionId(sessionId);
+			}
+			break;
+
+		case "session_name_changed":
+			// Update single-session store only if active
+			if (isActiveSession) {
+				setSessionName(event.name);
+			}
+			break;
+
+		case "model_changed":
+			console.log("[event-handlers] model_changed event:", {
+				sessionId,
+				isActiveSession,
+				model: event.model,
+			});
+			// Update single-session store only if active
+			if (isActiveSession) {
+				setModel(event.model);
+			}
+			break;
+
+		case "thinking_level_changed":
+			if (isActiveSession) {
+				setThinkingLevel(event.level);
+			}
+			break;
+
+		case "state_update":
+			// Update message count in session list
+			updateSessionMeta(sessionId, {
+				messageCount: event.state.messageCount,
+			});
+
+			if (isActiveSession) {
+				updateSessionState(event.state);
+			}
+			break;
+
+		// ─── Agent lifecycle ───────────────────────────────────────────────
+		case "agent_start":
+			if (isActiveSession) {
+				setStreaming(true);
+			}
+			break;
+
+		case "agent_end":
+			if (isActiveSession) {
+				setStreaming(false);
+			}
+			break;
+
+		// ─── Message streaming ─────────────────────────────────────────────
+		case "message_start":
+			if (isActiveSession && event.message?.role === "assistant") {
+				startAssistantMessage();
+			}
+			break;
+
+		case "message_update": {
+			if (!isActiveSession) break;
+
+			const ame = event.assistantMessageEvent;
+
+			switch (ame.type) {
+				case "text_delta":
+					// Use the accumulated text from the partial assistant message
+					appendStreamToken(
+						ame.partial?.content
+							?.filter((c: any) => c.type === "text")
+							.map((c: any) => c.text)
+							.join("") ?? "",
+					);
+					break;
+
+				case "thinking_start":
+					startThinking();
+					break;
+
+				case "thinking_delta":
+					appendThinkingToken(
+						ame.partial?.content
+							?.filter((c: any) => c.type === "thinking")
+							.map((c: any) => c.thinking)
+							.join("") ?? "",
+					);
+					break;
+
+				case "thinking_end":
+					endThinking();
+					break;
+			}
+			break;
+		}
+
+		case "message_end":
+			if (isActiveSession) {
+				if (event.message?.role === "assistant") {
+					endAssistantMessage();
+				} else if (event.message?.role === "user") {
+					// Update session title with the latest user message
+					const textContent = event.message.content
+						?.filter((c: any) => c.type === "text")
+						.map((c: any) => c.text)
+						.join(" ");
+					if (textContent) {
+						const title = textContent.substring(0, 100);
+						updateSessionMeta(sessionId, { title });
+					}
+				}
+			}
+			break;
+
+		// ─── Turn lifecycle ────────────────────────────────────────────────
+		case "turn_start":
+		case "turn_end":
+			break;
+
+		// ─── Tool execution ────────────────────────────────────────────────
+		case "tool_execution_start":
+			if (isActiveSession) {
+				console.log("[event-handlers] Tool execution:", event.toolName);
+			}
+			break;
+
+		case "tool_execution_update":
+			break;
+
+		case "tool_execution_end":
+			break;
+
+		// ─── Compaction ────────────────────────────────────────────────────
+		case "compact_start":
+		case "auto_compaction_start":
+			if (isActiveSession) {
+				setCompacting(true);
+			}
+			break;
+
+		case "compact_end":
+		case "auto_compaction_end":
+			if (isActiveSession) {
+				setCompacting(false);
+			}
+			break;
+
+		// ─── Errors ────────────────────────────────────────────────────────
+		case "error":
+			console.error("[event-handlers] Agent error:", event.error);
+			break;
+
+		default:
+			console.log("[event-handlers] Unhandled event:", event);
+	}
+}
+
+/**
+ * Handle auth events from the WebSocket.
+ * Updates the auth store's login flow state.
+ */
+export function handleAuthEvent(event: AuthEvent): void {
+	console.log("[event-handlers] Auth event:", event);
+	updateLoginFlow(event);
+}


### PR DESCRIPTION
## Summary

Extracts event handling logic from the ClientManager singleton into pure, testable functions. This is the core refactoring from #55 Step 2 that enables comprehensive testing of the event→store→component pipeline.

## Problem

The ClientManager had ~200 lines of event handling logic in private methods, making it impossible to test event dispatch without mocking WebSocket connections. This created a testing blind spot for the most critical part of the application: how WebSocket events map to store updates.

## Solution

Extract `handleEvent` and `handleAuthEvent` into a new `event-handlers.ts` module with pure functions that accept `activeSessionId` as a parameter instead of reading from the store internally.

## Changes

### New: `src/lib/event-handlers.ts`
- **`handleSessionEvent(sessionId, event, activeSessionId)`** — dispatches session events to store actions
- **`handleAuthEvent(event)`** — updates auth login flow state
- Pure functions, no side effects beyond store updates
- Maintains all active session gating logic
- Handles all event types:
  - Session lifecycle (session_start, model_changed, thinking_level_changed, state_update)
  - Agent lifecycle (agent_start/end)
  - Message streaming (message_start/update/end, thinking flow)
  - Compaction (compact_start/end, auto_compaction_start/end)
  - Tool execution, errors, RPC responses

### Modified: `src/lib/client-manager.ts`
- Removed 200+ lines of private event handling methods
- Updated `connect()` to call extracted handlers
- Reads `activeSessionId` from `sessionsListStore.state` and passes to handler
- Clean up imports: removed unused `updateSessionMeta`, added missing `setSessionName`

### New: `src/lib/__tests__/event-handlers.test.ts` (39 tests)

#### Session lifecycle events (10 tests)
- ✅ `session_start` adds to sessions list, sets sessionId if active
- ✅ `session_name_changed` updates session store (active only)
- ✅ `model_changed` updates model (active only)
- ✅ `thinking_level_changed` updates level (active only)
- ✅ `state_update` updates message count in list + session store (active only)
- ✅ All events respect active session gating

#### Agent lifecycle events (4 tests)
- ✅ `agent_start/end` toggles `isStreaming` (active only)

#### Message streaming events (11 tests)
- ✅ `message_start` creates assistant message (active only, assistant role only)
- ✅ `message_update` with `text_delta` appends content
- ✅ `message_update` with thinking lifecycle (start/delta/end)
- ✅ `message_end` for assistant ends streaming
- ✅ `message_end` for user extracts title (first 100 chars)
- ✅ All updates respect active session gating

#### Compaction events (5 tests)
- ✅ `compact_start/end` and `auto_compaction_start/end` toggle `isCompacting` (active only)

#### Edge cases (5 tests)
- ✅ RPC response events logged and ignored
- ✅ Unhandled events (turn_start/end, tool_execution) handled gracefully
- ✅ Error events logged

#### Auth events (4 tests)
- ✅ url, prompt, complete events update login flow
- ✅ Events for wrong `loginFlowId` ignored

## Test Results
```
✅ Test Files  7 passed (7)
✅ Tests       125 passed (125)
   - 86 store tests (from #70)
   - 39 event handler tests (new)
✅ Typecheck   clean
```

## Benefits
1. **Testability**: Event handlers can now be tested in isolation without WebSocket mocks
2. **Maintainability**: Event dispatch logic is in one place, not spread across ClientManager
3. **Clarity**: Pure functions with explicit dependencies (activeSessionId parameter)
4. **Foundation**: Enables integration tests (event → store → component) in next PR

## Addresses
- Implements #55 Step 2
- Addresses #69 (event handler extraction)

## Next Steps
- Presentational component tests (#54 Step 6)
- Integration tests: event → store → render (#55 Step 4)