### PR TITLE
feat: add reload RPC to refresh extensions after chat-based install

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -80,6 +80,7 @@ type RpcCommand =
 	| { id?: string; type: "get_extensions" }
 	| { id?: string; type: "get_skills" }
 	| { id?: string; type: "install_package"; source: string; local?: boolean }
+	| { id?: string; type: "reload" }
 	| { id?: string; type: "get_auth_providers" }
 	| { id?: string; type: "auth_login"; providerId: string }
 	| { id?: string; type: "auth_set_api_key"; providerId: string; apiKey: string }
@@ -803,6 +804,11 @@ export class WebChannel implements Channel {
 						error: err instanceof Error ? err.message : String(err),
 					};
 				}
+			}
+
+			case "reload": {
+				await session.reload();
+				return { id, type: "response", command: "reload", success: true };
 			}
 
 			default: {

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -252,6 +252,10 @@ export class ClankieClient {
 		return response as { output: string; exitCode: number };
 	}
 
+	async reload(sessionId: string): Promise<void> {
+		await this.sendCommand({ type: "reload" }, sessionId);
+	}
+
 	// ─── Internal ──────────────────────────────────────────────────────────────
 
 	private handleMessage(message: OutboundWebMessage | RpcResponse): void {

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -69,6 +69,7 @@ export type RpcCommand =
 	| { id?: string; type: "get_extensions" }
 	| { id?: string; type: "get_skills" }
 	| { id?: string; type: "install_package"; source: string; local?: boolean }
+	| { id?: string; type: "reload" }
 	| { id?: string; type: "get_auth_providers" }
 	| { id?: string; type: "auth_login"; providerId: string }
 	| {

--- a/web-ui/src/routes/extensions.tsx
+++ b/web-ui/src/routes/extensions.tsx
@@ -48,6 +48,9 @@ function ExtensionsPage() {
 
 		setLoading(true);
 		try {
+			// Reload session resources first to pick up extensions installed via chat
+			await client.reload(activeSessionId);
+
 			const [extensionsResult, skillsResult] = await Promise.all([
 				client.getExtensions(activeSessionId),
 				client.getSkills(activeSessionId),


### PR DESCRIPTION
## Problem

When an extension is installed **via chat** (the agent runs `pi install X` through the bash tool), the extensions list on the `/extensions` page does not show the newly installed extension. The user has to restart the server to see it.

Installing via the **extensions page UI** works fine because it calls `session.reload()` after installation.

## Root Cause

When installing via chat, the bash tool has no idea it ran an install command. `session.reload()` is never called, so `session.resourceLoader.getExtensions()` returns stale data.

## Solution

Added a `reload` RPC command to the web channel, and the extensions page now calls it before fetching extension/skill data. This mirrors the `/reload` slash command in the terminal.

## Changes

1. **`src/channels/web.ts`** — Added `reload` RPC command type + handler (calls `session.reload()`)
2. **`web-ui/src/lib/types.ts`** — Added `reload` to `RpcCommand` union
3. **`web-ui/src/lib/clankie-client.ts`** — Added `reload(sessionId)` method
4. **`web-ui/src/routes/extensions.tsx`** — Calls `client.reload()` before fetching extensions/skills in `loadExtensionsAndSkills`

## Testing

- TypeScript compiles cleanly
- No new linting errors introduced
- Manually tested: installing via chat now shows up in extensions list after page reload

Fixes #75