### PR TITLE
fix: correct @hono/node-server serve() usage

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -359,19 +359,16 @@ export class WebChannel implements Channel {
 
 		// ─── Start server ─────────────────────────────────────────────────────
 
-		const serverInfo = await new Promise<{ address: string; port: number; server: Server }>((resolve) => {
-			const _info = serve(
-				{
-					fetch: app.fetch,
-					port: this.options.port,
-				},
-				(info) => {
-					resolve(info as { address: string; port: number; server: Server });
-				},
-			);
-		});
+		this.server = serve(
+			{
+				fetch: app.fetch,
+				port: this.options.port,
+			},
+			(info) => {
+				console.log(`[web] Server started on ${info.address}:${info.port}`);
+			},
+		);
 
-		this.server = serverInfo.server;
 		injectWebSocket(this.server);
 
 		console.log(`[web] WebSocket server listening on port ${this.options.port}`);


### PR DESCRIPTION
## Problem

After merging #78 (Bun → Node + Hono migration), the daemon crashes on startup with:

```
Fatal error: Cannot read properties of undefined (reading 'on')
```

## Root Cause

The `serve()` function from `@hono/node-server` returns the HTTP Server object **directly**, not through a promise callback. The previous code incorrectly wrapped it in a Promise, causing `this.server` to be set to an object with `{ server: Server }` structure instead of the Server itself.

When `injectWebSocket(this.server)` tried to call `.on()` on the malformed object, it failed.

## Fix

- Remove the incorrect Promise wrapper
- Assign `serve()` result directly to `this.server`
- Keep the optional callback for logging (it fires after the server starts listening)

## Testing

```bash
$ node --experimental-strip-types src/cli.ts start
[daemon] Starting clankie daemon (pid 28055)...
[daemon] Workspace: /Users/thiagovarela/.clankie/workspace
[daemon] Channels: web
[web] Server started on :::3100
[web] WebSocket server listening on port 3100
[daemon] Ready. Waiting for messages...
✓ Server starts successfully
```

```bash
$ curl http://localhost:3100/
Upgrade Required - this endpoint only accepts WebSocket connections
✓ Correct response for non-WebSocket requests
```

## Files Changed

- `src/channels/web.ts`: Fix `serve()` call (-13 lines, +10 lines)