### PR TITLE
fix(web-ui): show assistant tool calls even before execution

### DIFF
--- a/web-ui/src/components/message-bubble.tsx
+++ b/web-ui/src/components/message-bubble.tsx
@@ -1,9 +1,14 @@
+import { useStore } from '@tanstack/react-store'
 import { Bot, Loader2, User } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ToolExecutionList } from './tool-execution-list'
 import type { DisplayMessage } from '@/stores/messages'
 import { cn } from '@/lib/utils'
+import {
+  hasToolExecutionsForMessage,
+  toolExecutionsStore,
+} from '@/stores/tool-executions'
 
 interface MessageBubbleProps {
   message: DisplayMessage
@@ -11,6 +16,13 @@ interface MessageBubbleProps {
 
 export function MessageBubble({ message }: MessageBubbleProps) {
   const isUser = message.role === 'user'
+
+  const hasToolExecutions = useStore(toolExecutionsStore, (state) =>
+    hasToolExecutionsForMessage(message.id, state),
+  )
+
+  const assistantMarkdown =
+    message.content || (hasToolExecutions ? '' : message.isStreaming ? '...' : '')
 
   return (
     <div className={cn('flex gap-3', isUser && 'justify-end')}>
@@ -43,11 +55,13 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         ) : (
           <>
             <ToolExecutionList messageId={message.id} />
-            <div className="prose prose-sm dark:prose-invert max-w-none">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {message.content || '...'}
-              </ReactMarkdown>
-            </div>
+            {assistantMarkdown && (
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {assistantMarkdown}
+                </ReactMarkdown>
+              </div>
+            )}
           </>
         )}
 

--- a/web-ui/src/lib/event-handlers.ts
+++ b/web-ui/src/lib/event-handlers.ts
@@ -7,6 +7,7 @@ import type { AgentSessionEvent, AuthEvent, RpcResponse } from '@/lib/types'
 import { updateLoginFlow } from '@/stores/auth'
 import {
   finishToolExecution,
+  registerToolCall,
   startToolExecution,
   updateToolExecution,
 } from '@/stores/tool-executions'
@@ -174,6 +175,35 @@ export function handleSessionEvent(
         case 'thinking_end':
           endThinking()
           break
+
+        case 'toolcall_end': {
+          const toolCall = ame.toolCall as
+            | {
+                id?: string
+                toolCallId?: string
+                name?: string
+                toolName?: string
+                arguments?: unknown
+                input?: unknown
+              }
+            | undefined
+
+          const toolCallId = toolCall?.id ?? toolCall?.toolCallId
+          const toolName = toolCall?.name ?? toolCall?.toolName
+          const args =
+            (toolCall?.arguments as Record<string, unknown> | undefined) ??
+            (toolCall?.input as Record<string, unknown> | undefined) ??
+            {}
+
+          if (toolCallId && toolName) {
+            registerToolCall({
+              toolCallId,
+              toolName,
+              args,
+            })
+          }
+          break
+        }
       }
       break
     }


### PR DESCRIPTION
## Problem
Tool calls triggered by assistant toolcall stream events were not rendered in chat unless tool_execution events were emitted and linked to a message.

This produced empty "..." assistant bubbles (tool-call-only assistant messages) and made users think tool calls were missing.

## Fix
- Track message_update assistant toolcall_end and register tool calls immediately
- Extend tool execution status lifecycle with called state
- Keep tool call/message linkage stable when execution starts later
- In message bubble, avoid rendering "..." placeholder when the message already has tool calls attached

## Validation
- web-ui: bun run typecheck ✅
- web-ui: bun run test src/lib/__tests__/event-handlers.test.ts ✅
- web-ui: bun run build ✅
