### PR TITLE
Fix tool calls not rendering after refresh/session switch

### DIFF
--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -7,7 +7,10 @@ import { handleAuthEvent, handleSessionEvent } from './event-handlers'
 import type { ExtensionUIResponse } from './types'
 import { connectionStore, updateConnectionStatus } from '@/stores/connection'
 import { clearMessages, setMessages } from '@/stores/messages'
-import { clearToolExecutions } from '@/stores/tool-executions'
+import {
+  clearToolExecutions,
+  hydrateToolExecutionsFromMessages,
+} from '@/stores/tool-executions'
 import {
   handleExtensionUIRequest,
   resetExtensionUI,
@@ -263,6 +266,7 @@ class ClientManager {
         `[client-manager] Loaded ${messages.length} messages for session ${sessionId}`,
       )
       setMessages(messages)
+      hydrateToolExecutionsFromMessages(messages)
 
       // Fetch and update session state
       const state = await this.client.getState(sessionId)

--- a/web-ui/src/stores/__tests__/tool-executions.test.ts
+++ b/web-ui/src/stores/__tests__/tool-executions.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearToolExecutions,
+  getToolExecutionsForMessage,
+  hydrateToolExecutionsFromMessages,
+  toolExecutionsStore,
+} from '../tool-executions'
+import type { Message } from '@/lib/types'
+
+describe('tool executions store', () => {
+  describe('hydrateToolExecutionsFromMessages', () => {
+    it('restores tool executions and links them to assistant message ids', () => {
+      const messages: Array<Message> = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'List files' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'call-1',
+              name: 'ls',
+              input: { path: '.' },
+            },
+          ],
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'ls',
+          content: [{ type: 'text', text: '.pi/' }],
+          isError: false,
+        },
+      ]
+
+      hydrateToolExecutionsFromMessages(messages)
+
+      const executions = getToolExecutionsForMessage(
+        'msg-1',
+        toolExecutionsStore.state,
+      )
+      expect(executions).toHaveLength(1)
+      expect(executions[0]).toMatchObject({
+        toolCallId: 'call-1',
+        toolName: 'ls',
+        args: { path: '.' },
+        status: 'completed',
+        isError: false,
+        messageId: 'msg-1',
+      })
+
+      const content = executions[0].result?.content as
+        | Array<{ type: 'text'; text: string }>
+        | undefined
+      expect(content?.[0]?.text).toBe('.pi/')
+    })
+
+    it('marks execution as error when historical toolResult is_error is true', () => {
+      const messages: Array<Message> = [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'call-2',
+              name: 'read',
+              input: { path: '/missing.txt' },
+            },
+          ],
+        },
+        {
+          role: 'toolResult',
+          toolCallId: 'call-2',
+          toolName: 'read',
+          content: [{ type: 'text', text: 'ENOENT' }],
+          isError: true,
+        },
+      ]
+
+      hydrateToolExecutionsFromMessages(messages)
+
+      const execution = toolExecutionsStore.state.executions['call-2']
+      expect(execution).toBeDefined()
+      expect(execution?.status).toBe('error')
+      expect(execution?.isError).toBe(true)
+    })
+
+    it('clears previous executions before hydrating', () => {
+      hydrateToolExecutionsFromMessages([
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'call-old',
+              name: 'ls',
+              input: { path: '.' },
+            },
+          ],
+        },
+      ])
+
+      hydrateToolExecutionsFromMessages([])
+
+      expect(toolExecutionsStore.state.executionOrder).toEqual([])
+      expect(toolExecutionsStore.state.executions).toEqual({})
+
+      clearToolExecutions()
+    })
+  })
+})

--- a/web-ui/src/test/setup.ts
+++ b/web-ui/src/test/setup.ts
@@ -11,6 +11,7 @@ import { extensionsStore } from '@/stores/extensions'
 import { messagesStore } from '@/stores/messages'
 import { sessionStore } from '@/stores/session'
 import { sessionsListStore } from '@/stores/sessions-list'
+import { toolExecutionsStore } from '@/stores/tool-executions'
 
 // Store initial states for reset
 const INITIAL_AUTH_STATE = {
@@ -67,6 +68,11 @@ const INITIAL_SESSIONS_LIST_STATE = {
   activeSessionId: null,
 }
 
+const INITIAL_TOOL_EXECUTIONS_STATE = {
+  executions: {},
+  executionOrder: [],
+}
+
 /**
  * Reset all stores to their initial state
  */
@@ -77,6 +83,7 @@ export function resetAllStores(): void {
   messagesStore.setState(() => INITIAL_MESSAGES_STATE)
   sessionStore.setState(() => INITIAL_SESSION_STATE)
   sessionsListStore.setState(() => INITIAL_SESSIONS_LIST_STATE)
+  toolExecutionsStore.setState(() => INITIAL_TOOL_EXECUTIONS_STATE)
 }
 
 // Clean up after each test


### PR DESCRIPTION
## Summary
- hydrate tool executions from historical `get_messages` payloads when switching sessions
- reconstruct tool call cards by linking assistant `tool_use` blocks to `toolResult` messages via `toolCallId`
- reset tool execution store in global test setup and add dedicated store tests for history hydration

## Validation
- `cd web-ui && bun run test`
- `cd web-ui && bun run typecheck`
- `cd web-ui && bun run check` *(fails due unrelated existing ESLint/tsconfig issues in `.output` and existing lint errors outside this change)*
