### PR TITLE
Add debug logs for tool hydration after session load

### DIFF
--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -265,6 +265,34 @@ class ClientManager {
       console.log(
         `[client-manager] Loaded ${messages.length} messages for session ${sessionId}`,
       )
+
+      const rolesSummary = messages.reduce(
+        (acc, msg) => {
+          const role = String(msg.role)
+          acc[role] = (acc[role] ?? 0) + 1
+          return acc
+        },
+        {} as Record<string, number>,
+      )
+      console.log('[client-manager] getMessages roles summary:', rolesSummary)
+
+      const assistantToolUseSummary = messages
+        .filter((msg) => msg.role === 'assistant' && Array.isArray(msg.content))
+        .map((msg, index) => {
+          const content = Array.isArray(msg.content) ? msg.content : []
+          return {
+            assistantIndex: index,
+            contentTypes: content.map((block: any) => block?.type),
+            toolUseIds: content
+              .filter((block: any) => block?.type === 'tool_use')
+              .map((block: any) => block?.id),
+          }
+        })
+      console.log(
+        '[client-manager] assistant content/tool_use summary:',
+        assistantToolUseSummary,
+      )
+
       setMessages(messages)
       hydrateToolExecutionsFromMessages(messages)
 


### PR DESCRIPTION
## Summary
- add debug logging in `switchSession()` to inspect historical message roles and assistant `tool_use` blocks after `getMessages`
- add verbose hydration logs in `hydrateToolExecutionsFromMessages()` to show:
  - per-message role/content shape
  - discovered `toolResult` call IDs
  - hydrated execution IDs and unmatched `tool_use` IDs

## Validation
- `cd web-ui && bun run typecheck`
- `cd web-ui && bun run test src/stores/__tests__/tool-executions.test.ts`
