### PR TITLE
Stop rendering tool calls inside chat messages

### DIFF
--- a/web-ui/src/components/assistant-message-content.tsx
+++ b/web-ui/src/components/assistant-message-content.tsx
@@ -1,21 +1,9 @@
-import { useStore } from '@tanstack/react-store'
-import {
-  CheckCircle2,
-  ChevronDown,
-  Clock3,
-  Loader2,
-  Wrench,
-} from 'lucide-react'
+import { ChevronDown, Clock3, Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { ToolExecutionList } from './tool-execution-list'
 import type { DisplayMessage } from '@/stores/messages'
 import { cn } from '@/lib/utils'
-import {
-  getToolExecutionsForMessage,
-  toolExecutionsStore,
-} from '@/stores/tool-executions'
 
 interface AssistantMessageContentProps {
   message: DisplayMessage
@@ -40,22 +28,13 @@ export function AssistantMessageContent({
 }: AssistantMessageContentProps) {
   const [isMetaExpanded, setIsMetaExpanded] = useState(false)
 
-  const executions = useStore(toolExecutionsStore, (state) =>
-    getToolExecutionsForMessage(message.id, state),
-  )
-
   const thinkingText =
     message.thinkingContent ?? message.persistedThinkingContent ?? ''
   const hasThinking = thinkingText.length > 0
-  const hasTools = executions.length > 0
-  const hasMeta = hasThinking || hasTools
-
-  const allToolsCompleted =
-    hasTools && executions.every((execution) => execution.status !== 'running')
 
   return (
     <>
-      {hasMeta && (
+      {hasThinking && (
         <div className="mb-3">
           <button
             className="flex w-full items-center justify-between rounded-md border border-border bg-background/60 px-3 py-2 text-left text-sm"
@@ -75,46 +54,24 @@ export function AssistantMessageContent({
 
           {isMetaExpanded && (
             <div className="mt-2 space-y-3 rounded-md border border-border bg-background/40 p-3">
-              {hasThinking && (
-                <div className="space-y-1.5 text-xs">
-                  <div className="flex items-center gap-1.5 text-muted-foreground">
-                    <Clock3 className="h-3.5 w-3.5" />
-                    <span className="font-medium">
-                      {message.isThinking ? 'Thinking...' : 'Thinking'}
-                    </span>
-                    {message.isThinking && (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    )}
-                  </div>
-                  <p className="whitespace-pre-wrap italic text-muted-foreground">
-                    {thinkingText}
-                  </p>
+              <div className="space-y-1.5 text-xs">
+                <div className="flex items-center gap-1.5 text-muted-foreground">
+                  <Clock3 className="h-3.5 w-3.5" />
+                  <span className="font-medium">
+                    {message.isThinking ? 'Thinking...' : 'Thinking'}
+                  </span>
+                  {message.isThinking && (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  )}
                 </div>
-              )}
-
-              {hasTools && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                    {allToolsCompleted ? (
-                      <CheckCircle2 className="h-3.5 w-3.5" />
-                    ) : (
-                      <Wrench className="h-3.5 w-3.5" />
-                    )}
-                    <span className="font-medium">
-                      {allToolsCompleted
-                        ? 'Done'
-                        : `Running ${executions.length} tool${executions.length > 1 ? 's' : ''}`}
-                    </span>
-                  </div>
-                  <ToolExecutionList messageId={message.id} />
-                </div>
-              )}
+                <p className="whitespace-pre-wrap italic text-muted-foreground">
+                  {thinkingText}
+                </p>
+              </div>
             </div>
           )}
         </div>
       )}
-
-      {!hasMeta && <ToolExecutionList messageId={message.id} />}
 
       <div className="prose prose-sm dark:prose-invert max-w-none">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>


### PR DESCRIPTION
## Summary
- remove ToolExecutionList rendering from assistant chat bubbles
- keep assistant bubble metadata focused on thinking only
- leave built-in tool execution visibility to the dedicated Tool Activity sheet

## Validation
- cd web-ui && bun run typecheck ✅
- cd web-ui && bun run test src/components/__tests__/message-bubble.test.tsx src/components/__tests__/chat-input.test.tsx ✅
- cd web-ui && bun run check ❌ (fails due pre-existing unrelated lint errors)