### PR TITLE
Hide empty assistant bubbles in chat

### DIFF
--- a/web-ui/src/stores/__tests__/messages.test.ts
+++ b/web-ui/src/stores/__tests__/messages.test.ts
@@ -91,6 +91,14 @@ describe('messages store', () => {
         isStreaming: false,
       })
     })
+
+    it('removes assistant message when it ends without text or thinking', () => {
+      startAssistantMessage()
+      endAssistantMessage()
+
+      const { messages } = messagesStore.state
+      expect(messages).toHaveLength(0)
+    })
   })
 
   describe('thinking lifecycle', () => {
@@ -232,6 +240,27 @@ describe('messages store', () => {
 
       const { messages } = messagesStore.state
       expect(messages[0].content).toBe('First text\n\nSecond text')
+    })
+
+    it('filters assistant messages that have only tool calls', () => {
+      const piMessages = [
+        {
+          role: 'assistant' as const,
+          content: [
+            {
+              type: 'toolCall' as const,
+              id: 'call-1',
+              name: 'read',
+              arguments: { path: 'README.md' },
+            },
+          ],
+        },
+      ]
+
+      setMessages(piMessages)
+
+      const { messages } = messagesStore.state
+      expect(messages).toHaveLength(0)
     })
 
     it('hydrates persisted thinking content from assistant messages', () => {


### PR DESCRIPTION
## Summary
- filter out historical assistant messages that have no text and no thinking content
- drop streaming assistant messages at endAssistantMessage when they finish empty
- prevent ... placeholder bubbles from tool-only or otherwise empty assistant messages
- add store tests for both historical filtering and empty-stream cleanup

## Validation
- cd web-ui && bun run typecheck ✅
- cd web-ui && bun run test src/stores/__tests__/messages.test.ts src/components/__tests__/message-bubble.test.tsx ✅
- cd web-ui && bun run check ❌ (fails due pre-existing unrelated lint errors)