### PR TITLE
feat(web-ui): render user attachment previews in message bubbles

### DIFF
--- a/web-ui/src/components/__tests__/message-attachments.test.tsx
+++ b/web-ui/src/components/__tests__/message-attachments.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MessageAttachments } from '../message-attachments'
+
+describe('MessageAttachments', () => {
+  it('renders nothing when attachments are missing', () => {
+    const { container } = render(<MessageAttachments attachments={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders image previews', () => {
+    render(
+      <MessageAttachments
+        attachments={[
+          {
+            type: 'image',
+            name: 'photo.png',
+            mimeType: 'image/png',
+            previewUrl: 'data:image/png;base64,abc123',
+          },
+        ]}
+      />,
+    )
+
+    const img = screen.getByRole('img', { name: 'photo.png' })
+    expect(img).toHaveAttribute('src', 'data:image/png;base64,abc123')
+  })
+
+  it('renders file pills', () => {
+    const { container } = render(
+      <MessageAttachments
+        attachments={[
+          { type: 'file', name: 'notes.pdf', mimeType: 'application/pdf' },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('notes.pdf')).toBeInTheDocument()
+    expect(
+      container.querySelector('svg[class*="lucide-file"]'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders mixed attachment types', () => {
+    render(
+      <MessageAttachments
+        attachments={[
+          {
+            type: 'image',
+            name: 'image.jpg',
+            mimeType: 'image/jpeg',
+            previewUrl: 'data:image/jpeg;base64,xyz',
+          },
+          { type: 'file', name: 'report.txt', mimeType: 'text/plain' },
+        ]}
+      />,
+    )
+
+    expect(screen.getByRole('img', { name: 'image.jpg' })).toBeInTheDocument()
+    expect(screen.getByText('report.txt')).toBeInTheDocument()
+  })
+})

--- a/web-ui/src/components/__tests__/message-bubble.test.tsx
+++ b/web-ui/src/components/__tests__/message-bubble.test.tsx
@@ -20,6 +20,51 @@ describe('MessageBubble', () => {
         container.querySelector('svg[class*="lucide-user"]'),
       ).toBeInTheDocument()
     })
+
+    it('renders image attachments in user messages', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: 'See image',
+        attachments: [
+          {
+            type: 'image',
+            name: 'photo.png',
+            mimeType: 'image/png',
+            previewUrl: 'data:image/png;base64,abc',
+          },
+        ],
+      })
+
+      render(<MessageBubble message={message} />)
+
+      const image = screen.getByRole('img', { name: 'photo.png' })
+      expect(image).toBeInTheDocument()
+      expect(image).toHaveAttribute('src', 'data:image/png;base64,abc')
+    })
+
+    it('renders file attachments in user messages', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: 'Attached file',
+        attachments: [{ type: 'file', name: 'spec.pdf' }],
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.getByText('spec.pdf')).toBeInTheDocument()
+    })
+
+    it('renders attachments without requiring text content', () => {
+      const message = makeDisplayMessage({
+        role: 'user',
+        content: '',
+        attachments: [{ type: 'file', name: 'empty.txt' }],
+      })
+
+      render(<MessageBubble message={message} />)
+
+      expect(screen.getByText('empty.txt')).toBeInTheDocument()
+    })
   })
 
   describe('assistant messages', () => {

--- a/web-ui/src/components/message-attachments.tsx
+++ b/web-ui/src/components/message-attachments.tsx
@@ -1,0 +1,54 @@
+import { File } from 'lucide-react'
+import type { DisplayAttachment } from '@/stores/messages'
+import { cn } from '@/lib/utils'
+
+interface MessageAttachmentsProps {
+  attachments?: Array<DisplayAttachment>
+}
+
+export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
+  if (!attachments || attachments.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {attachments.map((attachment, index) => {
+        const key = `${attachment.type}-${attachment.name ?? 'unnamed'}-${index}`
+
+        if (attachment.type === 'image' && attachment.previewUrl) {
+          return (
+            <a
+              key={key}
+              href={attachment.previewUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="block"
+            >
+              <img
+                src={attachment.previewUrl}
+                alt={attachment.name ?? 'Attached image'}
+                className="h-20 w-20 rounded-md border border-primary-foreground/25 object-cover transition-opacity hover:opacity-90"
+              />
+            </a>
+          )
+        }
+
+        return (
+          <div
+            key={key}
+            className={cn(
+              'inline-flex max-w-full items-center gap-2 rounded-md border px-2 py-1',
+              'border-primary-foreground/25 bg-primary-foreground/10 text-primary-foreground',
+            )}
+          >
+            <File className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate text-xs font-medium">
+              {attachment.name ?? 'Attached file'}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web-ui/src/components/message-bubble.tsx
+++ b/web-ui/src/components/message-bubble.tsx
@@ -1,5 +1,6 @@
 import { Bot, User } from 'lucide-react'
 import { AssistantMessageContent } from './assistant-message-content'
+import { MessageAttachments } from './message-attachments'
 import type { DisplayMessage } from '@/stores/messages'
 import { cn } from '@/lib/utils'
 
@@ -25,7 +26,12 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         )}
       >
         {isUser ? (
-          <p className="whitespace-pre-wrap">{message.content}</p>
+          <>
+            <MessageAttachments attachments={message.attachments} />
+            {message.content ? (
+              <p className="whitespace-pre-wrap">{message.content}</p>
+            ) : null}
+          </>
         ) : (
           <AssistantMessageContent message={message} />
         )}

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -137,11 +137,18 @@ export interface MessageContentThinking {
   thinking: string
 }
 
+export interface MessageContentImage {
+  type: 'image'
+  data: string
+  mimeType: string
+}
+
 export type MessageContent =
   | MessageContentText
   | MessageContentToolUse
   | MessageContentToolResult
   | MessageContentThinking
+  | MessageContentImage
 
 export interface Message {
   role: string // Can be "user", "assistant", "toolResult", "bashExecution", "custom", "branchSummary", "compactionSummary"


### PR DESCRIPTION
## Summary
- add structured user message attachment support in `messagesStore`
- render attachment previews in user bubbles via new `MessageAttachments` component
- keep prompt payload behavior unchanged while removing `[Attached: ...]` marker lines from user-visible bubble text
- hydrate image and file attachments when loading session history
- add focused tests for store parsing and bubble/component rendering

## Testing
- `cd web-ui && bun run typecheck`
- `cd web-ui && bun x vitest run src/components/__tests__/chat-input.test.tsx src/components/__tests__/message-bubble.test.tsx src/components/__tests__/message-attachments.test.tsx src/stores/__tests__/messages.test.ts`
- `cd web-ui && bun run check` *(fails due to pre-existing lint errors in unrelated files: auth-login-dialog.tsx, nav-sessions.tsx, ui/chart.tsx, ui/field.tsx)*

Closes #102
