### PR TITLE
fix: Linux daemon service tries to run /workspace/start

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -35,12 +35,17 @@ function _resolveAppBinary(): string {
 }
 
 function resolveProgramArguments(): string[] {
-	if (!process.argv[1]?.endsWith(".ts")) {
-		// Compiled binary
-		return [process.argv[0], "start", "--foreground"];
+	const runtime = process.execPath || process.argv[0];
+	const entry = process.argv[1];
+	const isScriptEntry = Boolean(entry && /\.(?:[cm]?js|ts)$/.test(entry));
+
+	if (isScriptEntry && entry) {
+		// Running via runtime + script entry (e.g., node dist/cli.js, bun src/cli.ts)
+		return [runtime, entry, "start", "--foreground"];
 	}
-	// Running from source with Node.js (TypeScript files)
-	return [process.argv[0], process.argv[1], "start", "--foreground"];
+
+	// Standalone executable invocation
+	return [runtime, "start", "--foreground"];
 }
 
 // ─── Systemd (Linux) ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix service  argument resolution for script-based installs
- include JS/TS entry script when generating daemon start command
- keep standalone executable fallback intact

## Root cause
When installed from npm, the service command was generated as  (missing ). With , Node tried to load  from that directory and failed with .

## Validation
- Checked 1 file in 6ms. No fixes applied. ✅
-  ❌ (script not defined in this repo)
- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 246.
Checked 119 files in 40ms. No fixes applied.
Found 182 errors.
Found 84 warnings. ❌ (pre-existing unrelated diagnostics in )
