### PR TITLE
feat(web-ui): consolidate thinking-only messages into compact indicator

### DIFF
--- a/web-ui/src/components/__tests__/thinking-steps-indicator.test.tsx
+++ b/web-ui/src/components/__tests__/thinking-steps-indicator.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { ThinkingStepsIndicator } from '../thinking-steps-indicator'
+import type { DisplayMessage } from '@/stores/messages'
+
+function makeThinkingOnlyMessage(
+  overrides: Partial<DisplayMessage> = {},
+): DisplayMessage {
+  return {
+    id: `msg-${Math.random()}`,
+    role: 'assistant',
+    content: '',
+    timestamp: Date.now(),
+    thinkingContent: 'Default thinking text',
+    ...overrides,
+  }
+}
+
+describe('ThinkingStepsIndicator', () => {
+  it('renders a compact indicator for a single thinking step', () => {
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'Analyzing the problem' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    expect(screen.getByText('💭 Thinking')).toBeInTheDocument()
+    expect(screen.getByText('1 step')).toBeInTheDocument()
+    expect(screen.getByText(/Analyzing the problem/)).toBeInTheDocument()
+  })
+
+  it('renders step count for multiple thinking steps', () => {
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'Step 1' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Step 2' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Step 3' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    expect(screen.getByText('3 steps')).toBeInTheDocument()
+  })
+
+  it('shows the latest thinking text when collapsed', () => {
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'First step' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Second step' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Final step is the latest' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    // Latest thinking text should be visible
+    expect(screen.getByText(/Final step is the latest/)).toBeInTheDocument()
+    // Earlier steps should not be visible when collapsed
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+  })
+
+  it('truncates long thinking text in collapsed state', () => {
+    const longText = 'a'.repeat(100)
+    const messages = [makeThinkingOnlyMessage({ thinkingContent: longText })]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    const displayedText = screen.getByText(/a+…/)
+    expect(displayedText.textContent).toHaveLength(51) // 50 chars + ellipsis
+  })
+
+  it('expands to show all thinking steps when clicked', async () => {
+    const user = userEvent.setup()
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'First thought' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Second thought' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Third thought' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    // Initially collapsed
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+
+    // Click to expand
+    const button = screen.getByRole('button')
+    await user.click(button)
+
+    // All steps should now be visible
+    expect(screen.getByText('1.')).toBeInTheDocument()
+    expect(screen.getByText('First thought')).toBeInTheDocument()
+    expect(screen.getByText('2.')).toBeInTheDocument()
+    expect(screen.getByText('Second thought')).toBeInTheDocument()
+    expect(screen.getByText('3.')).toBeInTheDocument()
+    expect(screen.getByText('Third thought')).toBeInTheDocument()
+  })
+
+  it('collapses again when clicked in expanded state', async () => {
+    const user = userEvent.setup()
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'First thought' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Second thought' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    const button = screen.getByRole('button')
+
+    // Expand
+    await user.click(button)
+    expect(screen.getByText('1.')).toBeInTheDocument()
+
+    // Collapse
+    await user.click(button)
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+  })
+
+  it('shows spinner when message is actively thinking', () => {
+    const messages = [
+      makeThinkingOnlyMessage({
+        thinkingContent: 'Currently thinking',
+        isThinking: true,
+      }),
+    ]
+
+    const { container } = render(<ThinkingStepsIndicator messages={messages} />)
+
+    // Check for spinner (Loader2 with animate-spin)
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('shows spinner when message is streaming', () => {
+    const messages = [
+      makeThinkingOnlyMessage({
+        thinkingContent: 'Streaming thought',
+        isStreaming: true,
+      }),
+    ]
+
+    const { container } = render(<ThinkingStepsIndicator messages={messages} />)
+
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('does not show spinner when messages are complete', () => {
+    const messages = [
+      makeThinkingOnlyMessage({
+        thinkingContent: 'Completed thought',
+        isThinking: false,
+        isStreaming: false,
+      }),
+    ]
+
+    const { container } = render(<ThinkingStepsIndicator messages={messages} />)
+
+    const spinner = container.querySelector('.animate-spin')
+    expect(spinner).not.toBeInTheDocument()
+  })
+
+  it('handles persistedThinkingContent for hydrated messages', () => {
+    const messages = [
+      makeThinkingOnlyMessage({
+        thinkingContent: undefined,
+        persistedThinkingContent: 'Persisted thought from history',
+      }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    expect(
+      screen.getByText(/Persisted thought from history/),
+    ).toBeInTheDocument()
+  })
+
+  it('renders (empty) when thinking text is empty', async () => {
+    const user = userEvent.setup()
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: '' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Valid thought' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    // Expand to see all steps
+    await user.click(screen.getByRole('button'))
+
+    expect(screen.getByText('(empty)')).toBeInTheDocument()
+    expect(screen.getByText('Valid thought')).toBeInTheDocument()
+  })
+
+  it('starts collapsed by default', () => {
+    const messages = [
+      makeThinkingOnlyMessage({ thinkingContent: 'First' }),
+      makeThinkingOnlyMessage({ thinkingContent: 'Second' }),
+    ]
+
+    render(<ThinkingStepsIndicator messages={messages} />)
+
+    // Numbered list should not be visible
+    expect(screen.queryByText('1.')).not.toBeInTheDocument()
+    expect(screen.queryByText('2.')).not.toBeInTheDocument()
+  })
+})

--- a/web-ui/src/components/assistant-message-content.tsx
+++ b/web-ui/src/components/assistant-message-content.tsx
@@ -73,11 +73,17 @@ export function AssistantMessageContent({
         </div>
       )}
 
-      <div className="prose prose-sm dark:prose-invert max-w-none">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {message.content || '...'}
-        </ReactMarkdown>
-      </div>
+      {message.content.trim().length > 0 ? (
+        <div className="prose prose-sm dark:prose-invert max-w-none">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {message.content}
+          </ReactMarkdown>
+        </div>
+      ) : message.isStreaming ? (
+        <div className="prose prose-sm dark:prose-invert max-w-none text-muted-foreground">
+          ...
+        </div>
+      ) : null}
     </>
   )
 }

--- a/web-ui/src/components/thinking-steps-indicator.tsx
+++ b/web-ui/src/components/thinking-steps-indicator.tsx
@@ -1,0 +1,100 @@
+import { Bot, ChevronDown, Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import type { DisplayMessage } from '@/stores/messages'
+import { cn } from '@/lib/utils'
+
+interface ThinkingStepsIndicatorProps {
+  messages: Array<DisplayMessage>
+}
+
+function getThinkingText(message: DisplayMessage): string {
+  return message.thinkingContent ?? message.persistedThinkingContent ?? ''
+}
+
+function truncateThinkingText(text: string, maxLength = 50): string {
+  const trimmed = text.trim().replace(/\s+/g, ' ')
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength)}…`
+}
+
+export function ThinkingStepsIndicator({
+  messages,
+}: ThinkingStepsIndicatorProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  // Determine if any message in the group is actively streaming/thinking
+  const isLive = messages.some((msg) => msg.isThinking || msg.isStreaming)
+
+  // Get the latest thinking text (from the last message in the group)
+  const latestMessage = messages[messages.length - 1]
+  const latestThinking = getThinkingText(latestMessage)
+  const latestThinkingTruncated = truncateThinkingText(latestThinking)
+
+  const stepCount = messages.length
+
+  return (
+    <div className="flex gap-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Bot className="h-4 w-4" />
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-left transition-colors',
+          'border-border/60 bg-muted/30 hover:bg-muted/50',
+          isExpanded && 'bg-muted/50',
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+            <span>💭 Thinking</span>
+            {isLive && <Loader2 className="h-3 w-3 animate-spin" />}
+          </div>
+
+          {!isExpanded && latestThinking && (
+            <>
+              <span className="text-xs text-muted-foreground">·</span>
+              <span className="min-w-0 truncate text-xs italic text-muted-foreground">
+                {latestThinkingTruncated}
+              </span>
+            </>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            {stepCount} {stepCount === 1 ? 'step' : 'steps'}
+          </span>
+          <ChevronDown
+            className={cn(
+              'h-3.5 w-3.5 text-muted-foreground transition-transform',
+              isExpanded && 'rotate-180',
+            )}
+          />
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="absolute left-11 right-0 mt-10 rounded-lg border border-border/60 bg-card/95 p-3 shadow-sm backdrop-blur-sm">
+          <ol className="space-y-2 text-xs">
+            {messages.map((msg, index) => {
+              const thinkingText = getThinkingText(msg)
+              return (
+                <li key={msg.id} className="flex gap-2 text-muted-foreground">
+                  <span className="shrink-0 font-medium text-primary">
+                    {index + 1}.
+                  </span>
+                  <span className="whitespace-pre-wrap italic">
+                    {thinkingText || '(empty)'}
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Fixes #107

During multi-turn agentic conversations (e.g., tool-use loops), each LLM turn creates a separate assistant message. When a turn contains only thinking (no text content), it was rendering as a full message bubble with a misleading `...` text placeholder, creating visual noise with 3+ identical-looking bubbles before the final response.

## Changes

### New `ThinkingStepsIndicator` component
- Compact, single-line element (~40px) that replaces N noisy full-size bubbles
- Shows latest thinking step, step count, and expand/collapse toggle
- Live indicator with spinner when actively thinking/streaming
- Expands to show numbered list of all thinking steps

### Updated `ChatMessages`
- Added `groupMessages()` helper to identify and group consecutive thinking-only assistant messages
- A "thinking-only" message = role is 'assistant', no text content, but has thinking content
- Groups don't span across user messages
- Updated render loop to use grouped rendering

### Cleaned up `AssistantMessageContent`
- Removed misleading `'...'` fallback for thinking-only messages
- Only shows `'...'` when actively streaming with no content yet

## Testing
- ✅ All existing tests pass
- ✅ Added 12 new tests for `ThinkingStepsIndicator` component
- ✅ Added 6 new tests for grouping logic in `ChatMessages`
- ✅ Typecheck passes
- ✅ No new lint issues

## Screenshots

### Before
Multiple full-sized bubbles for each thinking step:
- Each shows "Assistant response" header
- Each has a thinking section
- Each shows misleading `...` text

### After
Single compact indicator:
- `💭 Thinking · [latest step text] ▸ 3 steps`
- Click to expand and see all steps
- Spinner when actively thinking

## Files Changed
- `web-ui/src/components/thinking-steps-indicator.tsx` — **NEW** compact thinking indicator component
- `web-ui/src/components/chat-messages.tsx` — Add grouping logic, update render loop
- `web-ui/src/components/assistant-message-content.tsx` — Clean up `...` fallback
- `web-ui/src/components/__tests__/thinking-steps-indicator.test.tsx` — **NEW** component tests
- `web-ui/src/components/__tests__/chat-messages.test.tsx` — Add grouping tests