### PR TITLE
Refactor web chat UI to Claude-style 1:1 conversation layout

### DIFF
--- a/web-ui/src/components/__tests__/message-bubble.test.tsx
+++ b/web-ui/src/components/__tests__/message-bubble.test.tsx
@@ -18,7 +18,7 @@ describe('MessageBubble', () => {
       expect(container.querySelector('.bg-primary')).toBeInTheDocument()
       expect(
         container.querySelector('svg[class*="lucide-user"]'),
-      ).toBeInTheDocument()
+      ).not.toBeInTheDocument()
     })
 
     it('renders image attachments in user messages', () => {
@@ -81,10 +81,10 @@ describe('MessageBubble', () => {
         screen.getByRole('button', { name: /a concise answer/i }),
       ).toBeInTheDocument()
       expect(screen.getAllByText('A concise answer')).toHaveLength(2)
-      expect(container.querySelector('.bg-muted')).toBeInTheDocument()
+      expect(container.querySelector('.bg-muted')).not.toBeInTheDocument()
       expect(
         container.querySelector('svg[class*="lucide-bot"]'),
-      ).toBeInTheDocument()
+      ).not.toBeInTheDocument()
     })
 
     it('keeps metadata collapsed by default and expands on click', () => {

--- a/web-ui/src/components/chat-input.tsx
+++ b/web-ui/src/components/chat-input.tsx
@@ -279,79 +279,81 @@ export function ChatInput() {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <div className="flex flex-col gap-2">
-        {/* Attachment previews */}
-        <AttachmentPreview
-          attachments={attachments}
-          onRemove={handleRemoveAttachment}
-        />
-
-        {/* Textarea with drag-drop indicator */}
-        <div className="relative">
-          <Textarea
-            ref={textareaRef}
-            id="chat-input"
-            name="message"
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            placeholder="Send a message... (Ctrl+Enter to send)"
-            className="min-h-[80px] resize-none"
-            disabled={!sessionId || isStreaming}
+      <div className="mx-auto w-full max-w-3xl">
+        <div className="flex flex-col gap-2">
+          {/* Attachment previews */}
+          <AttachmentPreview
+            attachments={attachments}
+            onRemove={handleRemoveAttachment}
           />
-          {isDragging && (
-            <div className="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-background/80 backdrop-blur-sm">
-              <p className="text-sm font-medium text-primary">
-                Drop files here
-              </p>
-            </div>
-          )}
-        </div>
 
-        {/* Toolbar row */}
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              onChange={handleFileInputChange}
-              className="hidden"
-              accept="image/*,application/pdf,text/*"
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
+          {/* Textarea with drag-drop indicator */}
+          <div className="relative">
+            <Textarea
+              ref={textareaRef}
+              id="chat-input"
+              name="message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
+              placeholder="Send a message... (Ctrl+Enter to send)"
+              className="min-h-[80px] resize-none"
               disabled={!sessionId || isStreaming}
-              onClick={() => fileInputRef.current?.click()}
-              title="Attach files"
-            >
-              <Paperclip className="h-4 w-4" />
-              <span className="sr-only">Attach files</span>
-            </Button>
-            <p className="text-xs text-muted-foreground">
-              <kbd className="rounded bg-muted px-1.5 py-0.5">Ctrl+Enter</kbd>{' '}
-              to send
-            </p>
+            />
+            {isDragging && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-background/80 backdrop-blur-sm">
+                <p className="text-sm font-medium text-primary">
+                  Drop files here
+                </p>
+              </div>
+            )}
           </div>
 
-          <div className="flex items-center gap-2">
-            <ToolActivitySheet disabled={!sessionId} />
-            <ModelSelector />
-            <Button
-              onClick={handleSend}
-              disabled={
-                (!message.trim() && attachments.length === 0) ||
-                !sessionId ||
-                isStreaming
-              }
-              size="icon"
-            >
-              <Send className="h-4 w-4" />
-              <span className="sr-only">Send message</span>
-            </Button>
+          {/* Toolbar row */}
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                onChange={handleFileInputChange}
+                className="hidden"
+                accept="image/*,application/pdf,text/*"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={!sessionId || isStreaming}
+                onClick={() => fileInputRef.current?.click()}
+                title="Attach files"
+              >
+                <Paperclip className="h-4 w-4" />
+                <span className="sr-only">Attach files</span>
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                <kbd className="rounded bg-muted px-1.5 py-0.5">Ctrl+Enter</kbd>{' '}
+                to send
+              </p>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <ToolActivitySheet disabled={!sessionId} />
+              <ModelSelector />
+              <Button
+                onClick={handleSend}
+                disabled={
+                  (!message.trim() && attachments.length === 0) ||
+                  !sessionId ||
+                  isStreaming
+                }
+                size="icon"
+              >
+                <Send className="h-4 w-4" />
+                <span className="sr-only">Send message</span>
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/web-ui/src/components/chat-messages.tsx
+++ b/web-ui/src/components/chat-messages.tsx
@@ -2,8 +2,8 @@ import { useStore } from '@tanstack/react-store'
 import { useEffect, useRef } from 'react'
 import { MessageBubble } from './message-bubble'
 import { ThinkingStepsIndicator } from './thinking-steps-indicator'
-import type {DisplayMessage} from '@/stores/messages';
-import {  messagesStore } from '@/stores/messages'
+import type { DisplayMessage } from '@/stores/messages'
+import { messagesStore } from '@/stores/messages'
 
 type MessageGroup =
   | { type: 'message'; message: DisplayMessage }
@@ -80,18 +80,20 @@ export function ChatMessages() {
   const groups = groupMessages(messages)
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 space-y-4">
-      {groups.map((group) =>
-        group.type === 'message' ? (
-          <MessageBubble key={group.message.id} message={group.message} />
-        ) : (
-          <ThinkingStepsIndicator
-            key={group.messages[0].id}
-            messages={group.messages}
-          />
-        ),
-      )}
-      <div ref={bottomRef} />
+    <div className="flex-1 overflow-y-auto px-4 py-6">
+      <div className="mx-auto w-full max-w-3xl space-y-4">
+        {groups.map((group) =>
+          group.type === 'message' ? (
+            <MessageBubble key={group.message.id} message={group.message} />
+          ) : (
+            <ThinkingStepsIndicator
+              key={group.messages[0].id}
+              messages={group.messages}
+            />
+          ),
+        )}
+        <div ref={bottomRef} />
+      </div>
     </div>
   )
 }

--- a/web-ui/src/components/message-bubble.tsx
+++ b/web-ui/src/components/message-bubble.tsx
@@ -1,4 +1,3 @@
-import { Bot, User } from 'lucide-react'
 import { AssistantMessageContent } from './assistant-message-content'
 import { MessageAttachments } from './message-attachments'
 import type { DisplayMessage } from '@/stores/messages'
@@ -12,17 +11,14 @@ export function MessageBubble({ message }: MessageBubbleProps) {
   const isUser = message.role === 'user'
 
   return (
-    <div className={cn('flex gap-3', isUser && 'justify-end')}>
-      {!isUser && (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
-          <Bot className="h-4 w-4" />
-        </div>
-      )}
-
+    <div
+      className={cn('flex w-full', isUser ? 'justify-end' : 'justify-start')}
+    >
       <div
         className={cn(
-          'max-w-[80%] rounded-lg px-4 py-2',
-          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted',
+          isUser
+            ? 'max-w-[75%] rounded-2xl bg-primary px-4 py-2.5 text-primary-foreground'
+            : 'w-full text-foreground',
         )}
       >
         {isUser ? (
@@ -37,15 +33,9 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         )}
 
         {message.isStreaming && !isUser && (
-          <span className="inline-block h-3 w-1 animate-pulse bg-current ml-1" />
+          <span className="ml-1 inline-block h-3 w-1 animate-pulse bg-current" />
         )}
       </div>
-
-      {isUser && (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
-          <User className="h-4 w-4" />
-        </div>
-      )}
     </div>
   )
 }

--- a/web-ui/src/components/thinking-steps-indicator.tsx
+++ b/web-ui/src/components/thinking-steps-indicator.tsx
@@ -1,4 +1,4 @@
-import { Bot, ChevronDown, Loader2 } from 'lucide-react'
+import { ChevronDown, Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import type { DisplayMessage } from '@/stores/messages'
 import { cn } from '@/lib/utils'
@@ -33,16 +33,12 @@ export function ThinkingStepsIndicator({
   const stepCount = messages.length
 
   return (
-    <div className="flex gap-3">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-        <Bot className="h-4 w-4" />
-      </div>
-
+    <div className="relative w-full">
       <button
         type="button"
         onClick={() => setIsExpanded((v) => !v)}
         className={cn(
-          'flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-left transition-colors',
+          'flex w-full min-w-0 items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-left transition-colors',
           'border-border/60 bg-muted/30 hover:bg-muted/50',
           isExpanded && 'bg-muted/50',
         )}
@@ -77,7 +73,7 @@ export function ThinkingStepsIndicator({
       </button>
 
       {isExpanded && (
-        <div className="absolute left-11 right-0 mt-10 rounded-lg border border-border/60 bg-card/95 p-3 shadow-sm backdrop-blur-sm">
+        <div className="mt-2 rounded-lg border border-border/60 bg-card/95 p-3 shadow-sm backdrop-blur-sm">
           <ol className="space-y-2 text-xs">
             {messages.map((msg, index) => {
               const thinkingText = getThinkingText(msg)


### PR DESCRIPTION
## Summary\n- remove avatar icons from message bubbles and thinking indicators\n- center conversation + input using a shared  column\n- switch assistant responses to plain flowing text (no muted bubble background)\n- keep user messages as right-aligned pills for clear role distinction\n- re-anchor expanded thinking panel below the trigger after avatar removal\n\nCloses #110\n\n## Validation\n-  ✅\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 250.
Checked 121 files in 66ms. No fixes applied.
Found 186 errors.
Found 84 warnings. ❌ (fails due pre-existing unrelated ESLint errors in files not touched by this PR)\n-  ✅\n