### PR TITLE
fix: daemon service startup failure when installed via bun

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -288,10 +288,10 @@ async function initializeChannels(): Promise<void> {
 }
 
 /**
- * Restart the daemon by stopping all channels, clearing cache, and reinitializing.
+ * Restart channels when config changes (internal helper for config watcher).
  */
-async function restartDaemon(): Promise<void> {
-	console.log("[daemon] Config changed — restarting...");
+async function restartChannels(): Promise<void> {
+	console.log("[daemon] Config changed — restarting channels...");
 
 	// Stop existing channels
 	for (const ch of activeChannels) {
@@ -305,7 +305,7 @@ async function restartDaemon(): Promise<void> {
 	// Reinitialize with fresh config
 	await initializeChannels();
 
-	console.log("[daemon] Restart complete.");
+	console.log("[daemon] Channels restarted.");
 }
 
 export async function startDaemon(): Promise<void> {
@@ -327,8 +327,8 @@ export async function startDaemon(): Promise<void> {
 			// Debounce: config writes often trigger multiple events (write + chmod)
 			if (debounceTimer) clearTimeout(debounceTimer);
 			debounceTimer = setTimeout(() => {
-				restartDaemon().catch((err) => {
-					console.error("[daemon] Restart failed:", err instanceof Error ? err.message : String(err));
+				restartChannels().catch((err) => {
+					console.error("[daemon] Channel restart failed:", err instanceof Error ? err.message : String(err));
 				});
 			}, 1000);
 		});
@@ -388,7 +388,7 @@ export async function restartDaemon(): Promise<void> {
 	}
 
 	console.log(`Restarting daemon (pid ${status.pid})...`);
-	
+
 	// Stop the daemon
 	if (!stopDaemon()) {
 		console.error("Failed to stop daemon. Aborting restart.");

--- a/src/service.ts
+++ b/src/service.ts
@@ -21,31 +21,21 @@ import { getAppDir } from "./config.ts";
 const SERVICE_NAME = "clankie";
 const LAUNCHD_LABEL = "ai.clankie.daemon";
 
-// ─── Resolve the app binary path ──────────────────────────────────────────────
-
-function _resolveAppBinary(): string {
-	// If running from a compiled binary, use its path
-	if (!process.argv[1]?.endsWith(".ts")) {
-		return process.argv[0];
-	}
-
-	// Running from source — use bun + script path
-	// Return the full command that systemd/launchd will use
-	return process.argv[0]; // bun binary path
-}
+// ─── Resolve the program arguments ────────────────────────────────────────────
 
 function resolveProgramArguments(): string[] {
 	const runtime = process.execPath || process.argv[0];
-	const entry = process.argv[1];
-	const isScriptEntry = Boolean(entry && /\.(?:[cm]?js|ts)$/.test(entry));
 
-	if (isScriptEntry && entry) {
-		// Running via runtime + script entry (e.g., node dist/cli.js, bun src/cli.ts)
-		return [runtime, entry, "start", "--foreground"];
-	}
+	// import.meta.filename always resolves to the actual file on disk,
+	// regardless of symlinks or how the process was invoked (bun, node, npm, etc.)
+	// In the bundle, this resolves to dist/cli.js. In dev, src/service.ts.
+	// We need the cli entry point, which is in the same directory.
+	const thisFile = import.meta.filename;
+	const cliEntry = thisFile.endsWith("service.ts")
+		? join(dirname(thisFile), "cli.ts") // dev: src/cli.ts
+		: join(dirname(thisFile), "cli.js"); // built: dist/cli.js
 
-	// Standalone executable invocation
-	return [runtime, "start", "--foreground"];
+	return [runtime, cliEntry, "start", "--foreground"];
 }
 
 // ─── Systemd (Linux) ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The clankie systemd service fails immediately on startup with:

```
Error: Cannot find module '/root/.clankie/workspace/start'
```

The generated systemd unit has a broken `ExecStart`:

```
ExecStart=/root/.local/share/mise/installs/node/24.14.0/bin/node start --foreground
```

It should include the path to `cli.js`.

## Root Cause

When clankie is installed via **bun** (`bun install -g clankie`), bun creates a symlink:

```
/root/.bun/bin/clankie -> ../install/global/node_modules/clankie/dist/cli.js
```

The `#!/usr/bin/env node` shebang causes the OS to run it with node, so:
- `process.execPath` → `/path/to/node`
- `process.argv[1]` → `/root/.bun/bin/clankie` (no `.js` extension)

`resolveProgramArguments()` checks if `process.argv[1]` ends in `.js`/`.ts`, which fails, so it returns `[node, "start", "--foreground"]` — missing the script path entirely.

## Changes

### 1. Fix `resolveProgramArguments()` in `src/service.ts`

Replace fragile `process.argv[1]` detection with `import.meta.filename`, which always resolves to the actual file regardless of symlinks or install method.

### 2. Fix duplicate function name in `src/daemon.ts`

Rename the internal `restartDaemon` to `restartChannels` to avoid shadowing the exported CLI version. This was causing the daemon to kill itself when config changed.

### 3. Remove dead code

Remove unused `_resolveAppBinary()` function.

## Testing

After deploying this fix to the server:

```bash
ssh -p 2222 clank@ssh.miniclankers.com
clankie daemon uninstall
clankie daemon install
systemctl --user status clankie
```

The service should start successfully.

Fixes #117