### PR TITLE
build: externalize native dependencies to reduce dist from 86MB to 12MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	],
 	"scripts": {
 		"dev": "bun src/cli.ts",
-		"build": "bun build src/cli.ts --outdir dist --target node --format esm && chmod +x dist/cli.js",
+		"build": "bun build src/cli.ts --outdir dist --target node --format esm --external koffi --external @silvia-odwyer/photon-node --external @mariozechner/clipboard && chmod +x dist/cli.js",
 		"build:web-ui": "cd web-ui && bun install && bun run build && cd .. && rm -rf web-ui-dist && cp -r web-ui/.output/public web-ui-dist",
 		"prepublishOnly": "bun run build && bun run build:web-ui",
 		"check": "biome check .",


### PR DESCRIPTION
## Changes

Updated the build command in `package.json` to externalize three native dependencies that clankie never uses:

- `koffi` — Windows-only terminal VT input (84MB installed, 18 .node binaries)
- `@silvia-odwyer/photon-node` — Image processing WASM (2.2MB)
- `@mariozechner/clipboard` — Native clipboard access (6.1MB)

All three are:
- Lazy-loaded (dynamic import/require inside try/catch)
- Gracefully degrade when missing
- Never hit by clankie's code paths (headless daemon, no TUI/images/clipboard)

## Results

| Metric | Before | After |
|--------|--------|-------|
| `dist/` size | 86MB | 12MB |
| `.node` files in dist | 18 | 0 |
| `cli.js` size | 12.7MB | 12.6MB |

## Testing

✅ `bun run build` succeeds  
✅ `./dist/cli.js --help` works  
✅ `./dist/cli.js --version` works  
✅ `./dist/cli.js config show` works  

## Note

This does **not** remove the `pi-coding-agent` dependency (we still need it for SDK symbols). It only prevents native binaries from being copied to `dist/`.

Fixes #120