### PR TITLE
feat: add heartbeat pi extension with configurable results storage

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -21,6 +21,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { getAgentDir, getAppDir, getAuthPath, getWorkspace, loadConfig } from "./config.ts";
 import { createCronExtension } from "./extensions/cron/index.ts";
+import { createHeartbeatExtension } from "./extensions/heartbeat/index.ts";
 import { createWorkspaceJailExtension } from "./extensions/workspace-jail.ts";
 
 export interface SessionOptions {
@@ -66,6 +67,7 @@ export async function createSession(options: SessionOptions = {}): Promise<Creat
 	// Build extension factories (workspace jail if enabled)
 	const extensionFactories: ExtensionFactory[] = [];
 	extensionFactories.push(createCronExtension());
+	extensionFactories.push(createHeartbeatExtension());
 	const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true; // default: enabled
 	if (restrictToWorkspace) {
 		const configuredAllowedPaths = config.agent?.allowedPaths ?? [];

--- a/src/extensions/heartbeat/index.ts
+++ b/src/extensions/heartbeat/index.ts
@@ -1,0 +1,98 @@
+import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { HeartbeatRunner } from "./runner.ts";
+
+let sharedRunner: HeartbeatRunner | null = null;
+let activeSessions = 0;
+
+function ensureRunner(cwd: string): HeartbeatRunner {
+	if (!sharedRunner) {
+		sharedRunner = new HeartbeatRunner({ cwd });
+	}
+	return sharedRunner;
+}
+
+async function handleHeartbeatCommand(args: string, _pi: ExtensionAPI, cwd: string): Promise<string> {
+	const runner = ensureRunner(cwd);
+	const action = args.trim().toLowerCase();
+
+	if (action === "on" || action === "start") {
+		const started = runner.start();
+		return started ? "✓ Heartbeat started" : "Heartbeat did not start (disabled interval or lock held).";
+	}
+
+	if (action === "off" || action === "stop") {
+		runner.stop();
+		return "✓ Heartbeat stopped";
+	}
+
+	if (action === "run" || action === "now") {
+		const result = await runner.runNow();
+		if (result.ok) {
+			return `✅ HEARTBEAT_OK (${(result.durationMs / 1000).toFixed(1)}s)\nSaved: ${result.resultsDir}/latest.json`;
+		}
+		return `🫀 Alert (${(result.durationMs / 1000).toFixed(1)}s)\nSaved: ${result.resultsDir}/latest.json`;
+	}
+
+	if (action === "reload") {
+		const settings = runner.reloadSettings();
+		return `✓ Heartbeat settings reloaded (every: ${settings.every}, resultsDir: ${settings.resultsDir})`;
+	}
+
+	const status = runner.getStatus();
+	const last = status.lastResult;
+	const lines = [
+		`Heartbeat: ${status.active ? "active" : "inactive"}${status.running ? " (running)" : ""}`,
+		`Runs: ${status.runCount} · OK: ${status.okCount} · Alerts: ${status.alertCount}`,
+		last ? `Last: ${last.timestamp} (${last.ok ? "OK" : "alert"})` : "Last: never",
+		last ? `Results: ${last.resultsDir}` : "Results: ~/.clankie/workspace/heartbeat",
+	];
+	return lines.join("\n");
+}
+
+export function createHeartbeatExtension(): ExtensionFactory {
+	return function heartbeatExtension(pi: ExtensionAPI) {
+		let cwd = process.cwd();
+
+		pi.on("session_start", (_event, ctx) => {
+			cwd = ctx.cwd;
+			activeSessions += 1;
+			const runner = ensureRunner(cwd);
+			const settings = runner.reloadSettings();
+
+			if (pi.getFlag("--heartbeat") === true || settings.enabled) {
+				const started = runner.start();
+				if (started) {
+					ctx.ui.setStatus("heartbeat", "🫀 heartbeat active");
+				}
+			}
+		});
+
+		pi.on("session_shutdown", () => {
+			activeSessions = Math.max(0, activeSessions - 1);
+			if (activeSessions === 0 && sharedRunner) {
+				sharedRunner.stop();
+				sharedRunner = null;
+			}
+		});
+
+		pi.registerFlag("heartbeat", {
+			description: "Enable heartbeat checks on session start",
+			type: "boolean",
+			default: false,
+		});
+
+		pi.registerCommand("heartbeat", {
+			description: "Heartbeat controls: /heartbeat on|off|status|run|reload",
+			getArgumentCompletions: (prefix: string) => {
+				const items = ["on", "off", "status", "run", "reload"];
+				return items.filter((item) => item.startsWith(prefix)).map((item) => ({ value: item, label: item }));
+			},
+			handler: async (args, ctx) => {
+				const text = await handleHeartbeatCommand(args, pi, cwd);
+				ctx.ui.notify(text, "info");
+			},
+		});
+	};
+}
+
+export type { HeartbeatRunResult, HeartbeatSettings, HeartbeatStats } from "./types.ts";

--- a/src/extensions/heartbeat/lock.ts
+++ b/src/extensions/heartbeat/lock.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAppDir } from "../../config.ts";
+
+const LOCK_PATH = join(getAppDir(), "heartbeat", "heartbeat.lock");
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export function acquireHeartbeatLock(): boolean {
+	mkdirSync(join(getAppDir(), "heartbeat"), { recursive: true });
+
+	if (existsSync(LOCK_PATH)) {
+		try {
+			const content = readFileSync(LOCK_PATH, "utf-8").trim();
+			const pid = Number.parseInt(content, 10);
+			if (!Number.isNaN(pid) && pid !== process.pid && isProcessAlive(pid)) {
+				return false;
+			}
+		} catch {
+			// stale lock, overwrite below
+		}
+	}
+
+	writeFileSync(LOCK_PATH, String(process.pid), "utf-8");
+	return true;
+}
+
+export function releaseHeartbeatLock(): void {
+	try {
+		const content = readFileSync(LOCK_PATH, "utf-8").trim();
+		const pid = Number.parseInt(content, 10);
+		if (pid === process.pid) {
+			unlinkSync(LOCK_PATH);
+		}
+	} catch {
+		// ignore
+	}
+}

--- a/src/extensions/heartbeat/prompt.ts
+++ b/src/extensions/heartbeat/prompt.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const HEARTBEAT_OK = "HEARTBEAT_OK";
+
+const DEFAULT_PROMPT = `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply ${HEARTBEAT_OK}.`;
+
+export function readHeartbeatMd(cwd: string): string | null {
+	const filePath = resolve(cwd, "HEARTBEAT.md");
+	try {
+		return readFileSync(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+export function isEffectivelyEmpty(content: string): boolean {
+	const stripped = content
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith("#"))
+		.join("")
+		.trim();
+	return stripped.length === 0;
+}
+
+export function buildPrompt(cwd: string, customPrompt: string | null): string {
+	if (customPrompt?.trim()) {
+		return customPrompt;
+	}
+
+	const heartbeatMd = readHeartbeatMd(cwd);
+	if (!heartbeatMd) {
+		return DEFAULT_PROMPT;
+	}
+
+	return `${DEFAULT_PROMPT}\n\nHEARTBEAT.md:\n\n${heartbeatMd}`;
+}

--- a/src/extensions/heartbeat/runner.ts
+++ b/src/extensions/heartbeat/runner.ts
@@ -1,0 +1,316 @@
+import { join } from "node:path";
+import {
+	AuthStorage,
+	createAgentSession,
+	DefaultResourceLoader,
+	ModelRegistry,
+	SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { getAgentDir, getAppDir, getAuthPath, loadConfig } from "../../config.ts";
+import { createCronExtension } from "../cron/index.ts";
+import { createWorkspaceJailExtension } from "../workspace-jail.ts";
+import { acquireHeartbeatLock, releaseHeartbeatLock } from "./lock.ts";
+import { buildPrompt, isEffectivelyEmpty, readHeartbeatMd } from "./prompt.ts";
+import { resolveHeartbeatSettings } from "./settings.ts";
+import { persistHeartbeatResult, resolveResultsDir } from "./storage.ts";
+import type { HeartbeatParsedResponse, HeartbeatRunResult, HeartbeatSettings, HeartbeatStats } from "./types.ts";
+
+const HEARTBEAT_OK = "HEARTBEAT_OK";
+
+function parseDurationToMs(value: string): number {
+	const trimmed = value.trim().toLowerCase();
+	const match = trimmed.match(/^(\d+)\s*([mh])$/);
+	if (!match) return 30 * 60_000;
+	const amount = Number.parseInt(match[1], 10);
+	if (!Number.isFinite(amount)) return 30 * 60_000;
+	if (match[2] === "h") return amount * 60 * 60_000;
+	return amount * 60_000;
+}
+
+function parseTimeOfDay(value: string): number | null {
+	const match = value.match(/^(\d{2}):(\d{2})$/);
+	if (!match) return null;
+	const hour = Number.parseInt(match[1], 10);
+	const minute = Number.parseInt(match[2], 10);
+	if (!Number.isInteger(hour) || !Number.isInteger(minute)) return null;
+	if (hour < 0 || hour > 24) return null;
+	if (minute < 0 || minute > 59) return null;
+	if (hour === 24 && minute !== 0) return null;
+	return hour * 60 + minute;
+}
+
+function getMinutesInTimezone(timezone?: string): number {
+	if (!timezone) {
+		const now = new Date();
+		return now.getHours() * 60 + now.getMinutes();
+	}
+
+	const formatter = new Intl.DateTimeFormat("en-GB", {
+		timeZone: timezone,
+		hour: "2-digit",
+		minute: "2-digit",
+		hourCycle: "h23",
+	});
+	const parts = formatter.formatToParts(new Date());
+	const hour = Number.parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
+	const minute = Number.parseInt(parts.find((p) => p.type === "minute")?.value ?? "0", 10);
+	return hour * 60 + minute;
+}
+
+function isWithinActiveHours(settings: HeartbeatSettings): boolean {
+	if (!settings.activeHours) return true;
+	const start = parseTimeOfDay(settings.activeHours.start);
+	const end = parseTimeOfDay(settings.activeHours.end);
+	if (start === null || end === null || start === end) return false;
+
+	const nowMinutes = getMinutesInTimezone(settings.activeHours.timezone);
+	if (start < end) {
+		return nowMinutes >= start && nowMinutes < end;
+	}
+	// Overnight window, e.g. 22:00 -> 06:00
+	return nowMinutes >= start || nowMinutes < end;
+}
+
+function parseHeartbeatResponse(response: string, ackMaxChars: number): HeartbeatParsedResponse {
+	const raw = response.trim();
+	let normalized = raw;
+	let ackMatched = false;
+
+	if (normalized.startsWith(HEARTBEAT_OK)) {
+		normalized = normalized.slice(HEARTBEAT_OK.length).trim();
+		ackMatched = true;
+	}
+	if (normalized.endsWith(HEARTBEAT_OK)) {
+		normalized = normalized.slice(0, -HEARTBEAT_OK.length).trim();
+		ackMatched = true;
+	}
+
+	const ok = ackMatched && normalized.length <= ackMaxChars;
+	return {
+		ok,
+		ackMatched,
+		response: raw,
+		normalizedResponse: normalized,
+	};
+}
+
+interface HeartbeatRunnerOptions {
+	cwd: string;
+}
+
+export class HeartbeatRunner {
+	private readonly cwd: string;
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private running = false;
+	private locked = false;
+	private settings: HeartbeatSettings;
+	private stats: HeartbeatStats = {
+		active: false,
+		running: false,
+		runCount: 0,
+		okCount: 0,
+		alertCount: 0,
+		lastRun: null,
+		lastResult: null,
+	};
+
+	constructor(options: HeartbeatRunnerOptions) {
+		this.cwd = options.cwd;
+		this.settings = resolveHeartbeatSettings(this.cwd);
+	}
+
+	reloadSettings(): HeartbeatSettings {
+		this.settings = resolveHeartbeatSettings(this.cwd);
+		if (this.isActive()) {
+			this.stop();
+			if (this.settings.enabled) {
+				this.start();
+			}
+		}
+		return this.settings;
+	}
+
+	start(): boolean {
+		if (this.timer) return true;
+		this.settings = resolveHeartbeatSettings(this.cwd);
+		const intervalMs = parseDurationToMs(this.settings.every);
+		if (intervalMs <= 0) {
+			return false;
+		}
+		if (!acquireHeartbeatLock()) {
+			return false;
+		}
+		this.locked = true;
+		this.stats.active = true;
+		this.timer = setInterval(() => {
+			void this.tick();
+		}, intervalMs);
+		return true;
+	}
+
+	stop(): void {
+		if (this.timer) {
+			clearInterval(this.timer);
+			this.timer = null;
+		}
+		if (this.locked) {
+			releaseHeartbeatLock();
+			this.locked = false;
+		}
+		this.stats.active = false;
+	}
+
+	isActive(): boolean {
+		return this.timer !== null;
+	}
+
+	isRunning(): boolean {
+		return this.running;
+	}
+
+	getStatus(): HeartbeatStats {
+		return {
+			...this.stats,
+			running: this.running,
+		};
+	}
+
+	async runNow(): Promise<HeartbeatRunResult> {
+		this.settings = resolveHeartbeatSettings(this.cwd);
+		return this.execute();
+	}
+
+	private async tick(): Promise<void> {
+		if (this.running) return;
+		if (!isWithinActiveHours(this.settings)) return;
+
+		const heartbeatMd = readHeartbeatMd(this.cwd);
+		if (heartbeatMd !== null && isEffectivelyEmpty(heartbeatMd)) {
+			return;
+		}
+
+		await this.execute();
+	}
+
+	private async execute(): Promise<HeartbeatRunResult> {
+		this.running = true;
+		this.stats.running = true;
+		const startedAt = Date.now();
+		const timestamp = new Date(startedAt).toISOString();
+		const runId = timestamp;
+		const resultsDir = resolveResultsDir(this.cwd, this.settings.resultsDir);
+
+		try {
+			const prompt = buildPrompt(this.cwd, this.settings.prompt);
+			const responseText = await this.runHeartbeatPrompt(prompt);
+			const parsed = parseHeartbeatResponse(responseText, this.settings.ackMaxChars);
+
+			const result: HeartbeatRunResult = {
+				runId,
+				timestamp,
+				durationMs: Date.now() - startedAt,
+				cwd: this.cwd,
+				resultsDir,
+				...parsed,
+			};
+
+			persistHeartbeatResult(result);
+			this.recordResult(result);
+			return result;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			const result: HeartbeatRunResult = {
+				runId,
+				timestamp,
+				durationMs: Date.now() - startedAt,
+				cwd: this.cwd,
+				resultsDir,
+				ok: false,
+				ackMatched: false,
+				response: `Error: ${message}`,
+				normalizedResponse: `Error: ${message}`,
+				error: message,
+			};
+			persistHeartbeatResult(result);
+			this.recordResult(result);
+			return result;
+		} finally {
+			this.running = false;
+			this.stats.running = false;
+		}
+	}
+
+	private recordResult(result: HeartbeatRunResult): void {
+		this.stats.lastRun = result.timestamp;
+		this.stats.lastResult = result;
+		this.stats.runCount += 1;
+		if (result.ok) {
+			this.stats.okCount += 1;
+		} else {
+			this.stats.alertCount += 1;
+		}
+	}
+
+	private async runHeartbeatPrompt(prompt: string): Promise<string> {
+		const config = loadConfig();
+		const agentDir = getAgentDir(config);
+		const authStorage = AuthStorage.create(getAuthPath());
+		const modelRegistry = new ModelRegistry(authStorage);
+		const cwd = this.cwd;
+
+		const extensionFactories = [createCronExtension()];
+		const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true;
+		if (restrictToWorkspace) {
+			const configuredAllowedPaths = config.agent?.allowedPaths ?? [];
+			const attachmentRoot = join(getAppDir(), "attachments");
+			const allowedPaths = Array.from(new Set([...configuredAllowedPaths, attachmentRoot]));
+			extensionFactories.push(createWorkspaceJailExtension(cwd, allowedPaths));
+		}
+
+		const loader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			extensionFactories,
+		});
+		await loader.reload();
+
+		const modelSpec = config.agent?.model?.primary;
+		let model: ReturnType<ModelRegistry["find"]> | undefined;
+		if (modelSpec) {
+			const slash = modelSpec.indexOf("/");
+			if (slash !== -1) {
+				const provider = modelSpec.substring(0, slash);
+				const modelId = modelSpec.substring(slash + 1);
+				model = modelRegistry.find(provider, modelId);
+			}
+		}
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			authStorage,
+			modelRegistry,
+			resourceLoader: loader,
+			sessionManager: SessionManager.inMemory(),
+			model,
+		});
+
+		try {
+			await session.prompt(prompt, { source: "extension" });
+			const state = session.state;
+			const lastMessage = state.messages[state.messages.length - 1];
+			if (!lastMessage || lastMessage.role !== "assistant") {
+				return "";
+			}
+
+			const text = lastMessage.content
+				.filter((content) => content.type === "text")
+				.map((content) => content.text)
+				.join("\n")
+				.trim();
+			return text;
+		} finally {
+			session.dispose();
+		}
+	}
+}

--- a/src/extensions/heartbeat/settings.ts
+++ b/src/extensions/heartbeat/settings.ts
@@ -1,0 +1,79 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SettingsManager } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, loadConfig } from "../../config.ts";
+import type { HeartbeatSettings } from "./types.ts";
+
+const DEFAULTS: HeartbeatSettings = {
+	enabled: false,
+	every: "30m",
+	activeHours: null,
+	prompt: null,
+	ackMaxChars: 300,
+	resultsDir: join(homedir(), ".clankie", "workspace", "heartbeat"),
+	showOk: false,
+};
+
+function toRecord(value: unknown): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return {};
+	}
+	return value as Record<string, unknown>;
+}
+
+function parseNamespace(raw: Record<string, unknown>): Partial<HeartbeatSettings> {
+	const activeHoursRaw = toRecord(raw.activeHours);
+
+	return {
+		enabled: typeof raw.enabled === "boolean" ? raw.enabled : undefined,
+		every: typeof raw.every === "string" ? raw.every : typeof raw.interval === "string" ? raw.interval : undefined,
+		activeHours:
+			typeof activeHoursRaw.start === "string" && typeof activeHoursRaw.end === "string"
+				? {
+						start: activeHoursRaw.start,
+						end: activeHoursRaw.end,
+						timezone: typeof activeHoursRaw.timezone === "string" ? activeHoursRaw.timezone : undefined,
+					}
+				: activeHoursRaw === null
+					? null
+					: undefined,
+		prompt: typeof raw.prompt === "string" ? raw.prompt : raw.prompt === null ? null : undefined,
+		ackMaxChars: typeof raw.ackMaxChars === "number" ? raw.ackMaxChars : undefined,
+		resultsDir: typeof raw.resultsDir === "string" ? raw.resultsDir : undefined,
+		showOk: typeof raw.showOk === "boolean" ? raw.showOk : undefined,
+	};
+}
+
+export function resolveHeartbeatSettings(cwd: string): HeartbeatSettings {
+	try {
+		const config = loadConfig();
+		const agentDir = getAgentDir(config);
+		const sm = SettingsManager.create(cwd, agentDir);
+		const global = toRecord(sm.getGlobalSettings());
+		const project = toRecord(sm.getProjectSettings());
+
+		const globalRaw = {
+			...toRecord(global.heartbeat),
+			...toRecord(global["pi-heartbeat"]),
+			...toRecord(global["clankie-heartbeat"]),
+		};
+		const projectRaw = {
+			...toRecord(project.heartbeat),
+			...toRecord(project["pi-heartbeat"]),
+			...toRecord(project["clankie-heartbeat"]),
+		};
+
+		const merged = {
+			...DEFAULTS,
+			...parseNamespace(globalRaw),
+			...parseNamespace(projectRaw),
+		};
+
+		return {
+			...merged,
+			ackMaxChars: Number.isFinite(merged.ackMaxChars) ? Math.max(0, Math.floor(merged.ackMaxChars)) : 300,
+		};
+	} catch {
+		return { ...DEFAULTS };
+	}
+}

--- a/src/extensions/heartbeat/storage.ts
+++ b/src/extensions/heartbeat/storage.ts
@@ -1,0 +1,36 @@
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import type { HeartbeatRunResult } from "./types.ts";
+
+export function resolveResultsDir(cwd: string, configuredDir: string): string {
+	if (configuredDir.startsWith("~/")) {
+		return join(homedir(), configuredDir.slice(2));
+	}
+	if (isAbsolute(configuredDir)) {
+		return configuredDir;
+	}
+	return resolve(cwd, configuredDir);
+}
+
+function safeTimestamp(ts: string): string {
+	return ts.replace(/[:]/g, "-");
+}
+
+export function persistHeartbeatResult(result: HeartbeatRunResult): void {
+	mkdirSync(result.resultsDir, { recursive: true });
+
+	const fileName = `${safeTimestamp(result.timestamp)}.json`;
+	const filePath = join(result.resultsDir, fileName);
+	const latestPath = join(result.resultsDir, "latest.json");
+
+	const json = `${JSON.stringify(result, null, 2)}\n`;
+
+	const tempFilePath = `${filePath}.tmp`;
+	writeFileSync(tempFilePath, json, "utf-8");
+	renameSync(tempFilePath, filePath);
+
+	const latestTemp = `${latestPath}.tmp`;
+	writeFileSync(latestTemp, json, "utf-8");
+	renameSync(latestTemp, latestPath);
+}

--- a/src/extensions/heartbeat/types.ts
+++ b/src/extensions/heartbeat/types.ts
@@ -1,0 +1,41 @@
+export interface HeartbeatActiveHours {
+	start: string;
+	end: string;
+	timezone?: string;
+}
+
+export interface HeartbeatSettings {
+	enabled: boolean;
+	every: string;
+	activeHours: HeartbeatActiveHours | null;
+	prompt: string | null;
+	ackMaxChars: number;
+	resultsDir: string;
+	showOk: boolean;
+}
+
+export interface HeartbeatParsedResponse {
+	ok: boolean;
+	ackMatched: boolean;
+	response: string;
+	normalizedResponse: string;
+}
+
+export interface HeartbeatRunResult extends HeartbeatParsedResponse {
+	runId: string;
+	timestamp: string;
+	durationMs: number;
+	cwd: string;
+	resultsDir: string;
+	error?: string;
+}
+
+export interface HeartbeatStats {
+	active: boolean;
+	running: boolean;
+	runCount: number;
+	okCount: number;
+	alertCount: number;
+	lastRun: string | null;
+	lastResult: HeartbeatRunResult | null;
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -21,6 +21,7 @@ import {
 import type { Attachment } from "./channels/channel.ts";
 import { type AppConfig, getAgentDir, getAppDir, getAuthPath, getWorkspace } from "./config.ts";
 import { createCronExtension } from "./extensions/cron/index.ts";
+import { createHeartbeatExtension } from "./extensions/heartbeat/index.ts";
 import { createWorkspaceJailExtension } from "./extensions/workspace-jail.ts";
 
 // ─── Session cache (one session per chat) ──────────────────────────────────────
@@ -53,6 +54,7 @@ export async function getOrCreateSession(chatKey: string, config: AppConfig): Pr
 	// Build extension factories (workspace jail if enabled)
 	const extensionFactories: ExtensionFactory[] = [];
 	extensionFactories.push(createCronExtension());
+	extensionFactories.push(createHeartbeatExtension());
 	const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true; // default: enabled
 	if (restrictToWorkspace) {
 		const configuredAllowedPaths = config.agent?.allowedPaths ?? [];


### PR DESCRIPTION
## Summary\n- add a new  pi extension under \n- run periodic heartbeat checks using extension lifecycle + commands ()\n- persist each run as JSON ( + ) in configurable \n- default results directory to \n- wire the extension into session creation paths ( and )\n\n## Notes\n- no changes to daemon, cli, or app config schema\n- settings are read via pi  namespaces: , , \n\n## Validation\n- Bundled 1736 modules in 124ms

  cli.js  12.72 MB  (entry point) ✅\n-  ❌ (script missing in repo)\n- tsconfig.json(4,13): error TS5110: Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'NodeNext'. ❌ (pre-existing tsconfig module/moduleResolution mismatch)\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 224.
Checked 128 files in 50ms. No fixes applied.
Found 171 errors.
Found 72 warnings.
Found 1 info. ❌ (pre-existing repository-wide Biome issues outside touched files)\n- Checked 9 files in 7ms. No fixes applied. ✅