### PR TITLE
feat: allow configuring heartbeat model

### DIFF
--- a/src/extensions/heartbeat/index.ts
+++ b/src/extensions/heartbeat/index.ts
@@ -35,14 +35,16 @@ async function handleHeartbeatCommand(args: string, _pi: ExtensionAPI, cwd: stri
 
 	if (action === "reload") {
 		const settings = runner.reloadSettings();
-		return `✓ Heartbeat settings reloaded (every: ${settings.every}, resultsDir: ${settings.resultsDir})`;
+		return `✓ Heartbeat settings reloaded (every: ${settings.every}, resultsDir: ${settings.resultsDir}, model: ${settings.model ?? "default"})`;
 	}
 
 	const status = runner.getStatus();
+	const settings = runner.getSettings();
 	const last = status.lastResult;
 	const lines = [
 		`Heartbeat: ${status.active ? "active" : "inactive"}${status.running ? " (running)" : ""}`,
 		`Runs: ${status.runCount} · OK: ${status.okCount} · Alerts: ${status.alertCount}`,
+		`Model: ${settings.model ?? "(default session model)"}`,
 		last ? `Last: ${last.timestamp} (${last.ok ? "OK" : "alert"})` : "Last: never",
 		last ? `Results: ${last.resultsDir}` : "Results: ~/.clankie/workspace/heartbeat",
 	];

--- a/src/extensions/heartbeat/runner.ts
+++ b/src/extensions/heartbeat/runner.ts
@@ -175,6 +175,10 @@ export class HeartbeatRunner {
 		};
 	}
 
+	getSettings(): HeartbeatSettings {
+		return { ...this.settings };
+	}
+
 	async runNow(): Promise<HeartbeatRunResult> {
 		this.settings = resolveHeartbeatSettings(this.cwd);
 		return this.execute();
@@ -274,7 +278,9 @@ export class HeartbeatRunner {
 		});
 		await loader.reload();
 
-		const modelSpec = config.agent?.model?.primary;
+		const configuredModelSpec = this.settings.model?.trim();
+		const fallbackModelSpec = config.agent?.model?.primary;
+		const modelSpec = configuredModelSpec || fallbackModelSpec;
 		let model: ReturnType<ModelRegistry["find"]> | undefined;
 		if (modelSpec) {
 			const slash = modelSpec.indexOf("/");

--- a/src/extensions/heartbeat/settings.ts
+++ b/src/extensions/heartbeat/settings.ts
@@ -12,6 +12,7 @@ const DEFAULTS: HeartbeatSettings = {
 	ackMaxChars: 300,
 	resultsDir: join(homedir(), ".clankie", "workspace", "heartbeat"),
 	showOk: false,
+	model: null,
 };
 
 function toRecord(value: unknown): Record<string, unknown> {
@@ -41,6 +42,7 @@ function parseNamespace(raw: Record<string, unknown>): Partial<HeartbeatSettings
 		ackMaxChars: typeof raw.ackMaxChars === "number" ? raw.ackMaxChars : undefined,
 		resultsDir: typeof raw.resultsDir === "string" ? raw.resultsDir : undefined,
 		showOk: typeof raw.showOk === "boolean" ? raw.showOk : undefined,
+		model: typeof raw.model === "string" ? raw.model : raw.model === null ? null : undefined,
 	};
 }
 

--- a/src/extensions/heartbeat/types.ts
+++ b/src/extensions/heartbeat/types.ts
@@ -12,6 +12,7 @@ export interface HeartbeatSettings {
 	ackMaxChars: number;
 	resultsDir: string;
 	showOk: boolean;
+	model: string | null;
 }
 
 export interface HeartbeatParsedResponse {


### PR DESCRIPTION
## Summary
- add `model` support in heartbeat extension settings
- allow `clankie-heartbeat.model` (`provider/model`) to override the model used for heartbeat runs
- keep fallback to existing `agent.model.primary` when heartbeat model is not configured
- expose configured model in `/heartbeat status` and `/heartbeat reload` output

## Validation
- `bun run build` ✅
- `bun run typecheck` ❌ (script missing in repo)
- `bunx biome check src/extensions/heartbeat` ✅
