### PR TITLE
feat: extension uiSpec support on /extensions (heartbeat POC)

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -12,7 +12,7 @@
 import * as crypto from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import type { Server } from "node:http";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
@@ -22,6 +22,7 @@ import { Hono } from "hono";
 import type { WSContext } from "hono/ws";
 import { buildApiKeyProviders } from "../auth/providers.ts";
 import { getAppDir, getAuthPath, loadConfig } from "../config.ts";
+import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
 import { getOrCreateSession } from "../sessions.ts";
 import type { Channel, MessageHandler } from "./channel.ts";
 
@@ -136,6 +137,119 @@ type RpcExtensionUIResponse =
 	| { type: "extension_ui_response"; id: string; value: string }
 	| { type: "extension_ui_response"; id: string; confirmed: boolean }
 	| { type: "extension_ui_response"; id: string; cancelled: true };
+
+interface ExtensionUISpec {
+	root: string;
+	elements: Record<string, unknown>;
+}
+
+interface ExtensionDescriptor {
+	path: string;
+	resolvedPath: string;
+	tools: Map<string, unknown>;
+	commands: Map<string, unknown>;
+	flags: Map<string, unknown>;
+	shortcuts: Map<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidExtensionUISpec(value: unknown): value is ExtensionUISpec {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	return typeof value.root === "string" && isRecord(value.elements);
+}
+
+function tryReadJson(filePath: string): unknown | undefined {
+	try {
+		const raw = readFileSync(filePath, "utf8");
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+function findPackageRoot(startDir: string): string | undefined {
+	let current = resolve(startDir);
+
+	while (true) {
+		const packageJsonPath = join(current, "package.json");
+		if (existsSync(packageJsonPath)) {
+			return current;
+		}
+
+		const parent = dirname(current);
+		if (parent === current) {
+			return undefined;
+		}
+		current = parent;
+	}
+}
+
+function getUiSpecCandidatePaths(extensionPath: string, resolvedPath: string): string[] {
+	const candidates = new Set<string>();
+
+	for (const pathValue of [resolvedPath, extensionPath]) {
+		if (!pathValue || pathValue.startsWith("<inline:")) {
+			continue;
+		}
+
+		const absolutePath = resolve(pathValue);
+		if (!existsSync(absolutePath)) {
+			continue;
+		}
+
+		if (statSync(absolutePath).isFile()) {
+			candidates.add(`${absolutePath}.ui.json`);
+			candidates.add(join(dirname(absolutePath), "ui-spec.json"));
+			const packageRoot = findPackageRoot(dirname(absolutePath));
+			if (packageRoot) {
+				candidates.add(join(packageRoot, "ui-spec.json"));
+			}
+			continue;
+		}
+
+		if (statSync(absolutePath).isDirectory()) {
+			candidates.add(join(absolutePath, "ui-spec.json"));
+			const packageRoot = findPackageRoot(absolutePath);
+			if (packageRoot) {
+				candidates.add(join(packageRoot, "ui-spec.json"));
+			}
+		}
+	}
+
+	return Array.from(candidates);
+}
+
+function resolveInlineExtensionUiSpec(ext: ExtensionDescriptor): ExtensionUISpec | undefined {
+	const commandNames = Array.from(ext.commands.keys());
+	const flagNames = Array.from(ext.flags.keys());
+	const isHeartbeatExtension = commandNames.includes("heartbeat") || flagNames.includes("heartbeat");
+	return isHeartbeatExtension ? HEARTBEAT_EXTENSION_UI_SPEC : undefined;
+}
+
+function resolveExtensionUiSpec(ext: ExtensionDescriptor): ExtensionUISpec | undefined {
+	if (ext.path.startsWith("<inline:")) {
+		return resolveInlineExtensionUiSpec(ext);
+	}
+
+	for (const candidatePath of getUiSpecCandidatePaths(ext.path, ext.resolvedPath)) {
+		if (!existsSync(candidatePath) || !statSync(candidatePath).isFile()) {
+			continue;
+		}
+
+		const parsed = tryReadJson(candidatePath);
+		if (isValidExtensionUISpec(parsed)) {
+			return parsed;
+		}
+	}
+
+	return undefined;
+}
 
 // ─── WebChannel ────────────────────────────────────────────────────────────────
 
@@ -850,18 +964,20 @@ export class WebChannel implements Channel {
 
 			case "get_extensions": {
 				const extensionsResult = session.resourceLoader.getExtensions();
-				// Filter out inline extensions (created programmatically, like workspace-jail)
-				// They have paths like '<inline:1>' and typically don't expose user-facing tools
 				const extensions = extensionsResult.extensions
-					.filter((ext) => !ext.path.startsWith("<inline:"))
-					.map((ext) => ({
-						path: ext.path,
-						resolvedPath: ext.resolvedPath,
-						tools: Array.from(ext.tools.keys()),
-						commands: Array.from(ext.commands.keys()),
-						flags: Array.from(ext.flags.keys()),
-						shortcuts: Array.from(ext.shortcuts.keys()),
-					}));
+					.map((ext) => {
+						const uiSpec = resolveExtensionUiSpec(ext as ExtensionDescriptor);
+						return {
+							path: ext.path,
+							resolvedPath: ext.resolvedPath,
+							tools: Array.from(ext.tools.keys()),
+							commands: Array.from(ext.commands.keys()),
+							flags: Array.from(ext.flags.keys()),
+							shortcuts: Array.from(ext.shortcuts.keys()),
+							uiSpec,
+						};
+					})
+					.filter((ext) => !ext.path.startsWith("<inline:") || Boolean(ext.uiSpec));
 
 				return {
 					id,

--- a/src/extensions/heartbeat/ui-spec.ts
+++ b/src/extensions/heartbeat/ui-spec.ts
@@ -1,0 +1,41 @@
+export const HEARTBEAT_EXTENSION_UI_SPEC = {
+	root: "heartbeat-card",
+	elements: {
+		"heartbeat-card": {
+			type: "Card",
+			props: {
+				title: "Heartbeat",
+				description: "Periodic health checks for your workspace",
+			},
+			children: ["heartbeat-stack"],
+		},
+		"heartbeat-stack": {
+			type: "Stack",
+			props: {
+				direction: "vertical",
+				gap: "sm",
+			},
+			children: ["heartbeat-description", "heartbeat-commands", "heartbeat-flags"],
+		},
+		"heartbeat-description": {
+			type: "Text",
+			props: {
+				text: "Use /heartbeat on|off|run|reload to control checks and --heartbeat to auto-start.",
+				variant: "muted",
+			},
+		},
+		"heartbeat-commands": {
+			type: "Text",
+			props: {
+				text: "Commands: /heartbeat on, /heartbeat off, /heartbeat run, /heartbeat reload",
+			},
+		},
+		"heartbeat-flags": {
+			type: "Badge",
+			props: {
+				text: "--heartbeat",
+				variant: "secondary",
+			},
+		},
+	},
+} as const;

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -8,6 +8,8 @@ import type {
   AgentSessionEvent,
   AuthEvent,
   AuthProvider,
+  ExtensionError,
+  ExtensionInfo,
   ExtensionUIRequest,
   ExtensionUIResponse,
   ImageContent,
@@ -243,30 +245,16 @@ export class ClankieClient {
   // ─── Extensions & Skills ───────────────────────────────────────────────────
 
   async getExtensions(sessionId: string): Promise<{
-    extensions: Array<{
-      path: string
-      resolvedPath: string
-      tools: Array<string>
-      commands: Array<string>
-      flags: Array<string>
-      shortcuts: Array<string>
-    }>
-    errors: Array<{ path: string; error: string }>
+    extensions: Array<ExtensionInfo>
+    errors: Array<ExtensionError>
   }> {
     const response = await this.sendCommand(
       { type: 'get_extensions' },
       sessionId,
     )
     return response as {
-      extensions: Array<{
-        path: string
-        resolvedPath: string
-        tools: Array<string>
-        commands: Array<string>
-        flags: Array<string>
-        shortcuts: Array<string>
-      }>
-      errors: Array<{ path: string; error: string }>
+      extensions: Array<ExtensionInfo>
+      errors: Array<ExtensionError>
     }
   }
 

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -386,6 +386,11 @@ export type ExtensionUIResponse =
 
 // ─── Extensions & Skills ───────────────────────────────────────────────────────
 
+export interface ExtensionUISpec {
+  root: string
+  elements: Record<string, unknown>
+}
+
 export interface ExtensionInfo {
   path: string
   resolvedPath: string
@@ -393,6 +398,7 @@ export interface ExtensionInfo {
   commands: Array<string>
   flags: Array<string>
   shortcuts: Array<string>
+  uiSpec?: ExtensionUISpec
 }
 
 export interface ExtensionError {

--- a/web-ui/src/routes/extensions.tsx
+++ b/web-ui/src/routes/extensions.tsx
@@ -22,6 +22,7 @@ import {
 import { Field, FieldLabel } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { clientManager } from '@/lib/client-manager'
+import { JsonRenderRenderer } from '@/lib/tool-renderers/json-render-renderer'
 import { connectionStore } from '@/stores/connection'
 import {
   extensionsStore,
@@ -292,6 +293,15 @@ function ExtensionsPage() {
                           </div>
                         )}
                       </div>
+
+                      {ext.uiSpec && (
+                        <div className="rounded-md border bg-muted/30 p-3">
+                          <p className="mb-2 text-xs font-medium text-muted-foreground">
+                            Extension UI
+                          </p>
+                          <JsonRenderRenderer spec={ext.uiSpec} />
+                        </div>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/web-ui/src/stores/__tests__/extensions.test.ts
+++ b/web-ui/src/stores/__tests__/extensions.test.ts
@@ -41,6 +41,15 @@ describe('extensions store', () => {
           commands: ['cmd1'],
           flags: [],
           shortcuts: [],
+          uiSpec: {
+            root: 'root',
+            elements: {
+              root: {
+                type: 'Text',
+                props: { text: 'Hello' },
+              },
+            },
+          },
         },
       ]
 
@@ -104,6 +113,33 @@ describe('extensions store', () => {
       expect(extensionsStore.state.extensions[0].path).toBe('new')
       expect(extensionsStore.state.extensionErrors).toHaveLength(1)
       expect(extensionsStore.state.extensionErrors[0].path).toBe('new-error')
+    })
+
+    it('supports extensions that include uiSpec', () => {
+      setExtensions(
+        [
+          {
+            path: 'ui-ext',
+            resolvedPath: 'ui-ext',
+            tools: [],
+            commands: ['heartbeat'],
+            flags: ['heartbeat'],
+            shortcuts: [],
+            uiSpec: {
+              root: 'card-1',
+              elements: {
+                'card-1': {
+                  type: 'Card',
+                  props: { title: 'Heartbeat' },
+                },
+              },
+            },
+          },
+        ],
+        [],
+      )
+
+      expect(extensionsStore.state.extensions[0].uiSpec?.root).toBe('card-1')
     })
   })
 


### PR DESCRIPTION
## Summary
- add optional `uiSpec` support to `get_extensions` payload in `src/channels/web.ts`
- add extension UI spec discovery/validation (`ui-spec.json` and `<extension-file>.ui.json` conventions, plus package root fallback)
- include inline extensions in response only when they expose `uiSpec`
- add heartbeat inline UI spec mapping (POC) and new `src/extensions/heartbeat/ui-spec.ts`
- propagate `uiSpec` through web UI types/client and render it on `/extensions` using `JsonRenderRenderer`
- update extensions store tests to cover `uiSpec` entries

## Notes
- `bun run typecheck` is not available at repo root (script missing).
- `bun run check` fails due pre-existing repo-wide formatting/lint diagnostics unrelated to this change.
- Verified `web-ui` typecheck and updated extensions store tests pass.

Closes #128
