### PR TITLE
fix: wrap JsonRenderRenderer with JSONUIProvider

### DIFF
--- a/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
+++ b/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
@@ -1,5 +1,5 @@
 import { defineCatalog } from '@json-render/core'
-import { Renderer, defineRegistry } from '@json-render/react'
+import { JSONUIProvider, Renderer, defineRegistry } from '@json-render/react'
 import { schema } from '@json-render/react/schema'
 import {
   shadcnComponentDefinitions,
@@ -17,5 +17,9 @@ const { registry } = defineRegistry(catalog, {
 })
 
 export function JsonRenderRenderer({ spec }: { spec: ExtensionUISpec }) {
-  return <Renderer spec={spec as any} registry={registry} />
+  return (
+    <JSONUIProvider registry={registry}>
+      <Renderer spec={spec as any} registry={registry} />
+    </JSONUIProvider>
+  )
 }


### PR DESCRIPTION
## Summary\n- wrap  with  in \n- fixes runtime error:  when rendering extension \n\n## Validation\n- :  ✅\n- root:  unavailable (script missing)\n- root: The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 224.
Checked 129 files in 41ms. No fixes applied.
Found 171 errors.
Found 72 warnings.
Found 1 info. fails due pre-existing repo-wide formatting/lint issues unrelated to this patch\n