### PR TITLE
feat: heartbeat extension configurable from /extensions

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -22,6 +22,12 @@ import { Hono } from "hono";
 import type { WSContext } from "hono/ws";
 import { buildApiKeyProviders } from "../auth/providers.ts";
 import { getAppDir, getAuthPath, loadConfig } from "../config.ts";
+import {
+	getHeartbeatUiConfig,
+	setHeartbeatUiConfig,
+	type HeartbeatUiConfig,
+} from "../extensions/heartbeat/settings.ts";
+import { reloadSharedHeartbeatRunnerSettings } from "../extensions/heartbeat/index.ts";
 import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
 import { getOrCreateSession } from "../sessions.ts";
 import type { Channel, MessageHandler } from "./channel.ts";
@@ -84,6 +90,13 @@ type RpcCommand =
 	| { id?: string; type: "get_messages" }
 	| { id?: string; type: "get_commands" }
 	| { id?: string; type: "get_extensions" }
+	| { id?: string; type: "get_extension_config"; extensionPath: string }
+	| {
+			id?: string;
+			type: "set_extension_config";
+			extensionPath: string;
+			config: Record<string, unknown>;
+	  }
 	| { id?: string; type: "get_skills" }
 	| { id?: string; type: "install_package"; source: string; local?: boolean }
 	| { id?: string; type: "reload" }
@@ -249,6 +262,36 @@ function resolveExtensionUiSpec(ext: ExtensionDescriptor): ExtensionUISpec | und
 	}
 
 	return undefined;
+}
+
+function isHeartbeatExtension(ext: ExtensionDescriptor): boolean {
+	const commandNames = Array.from(ext.commands.keys());
+	const flagNames = Array.from(ext.flags.keys());
+	return commandNames.includes("heartbeat") || flagNames.includes("heartbeat");
+}
+
+function normalizeHeartbeatConfigInput(config: Record<string, unknown>): HeartbeatUiConfig {
+	const enabled = config.enabled;
+	const every = config.every;
+	const model = config.model;
+
+	if (typeof enabled !== "boolean") {
+		throw new Error("Invalid heartbeat config: 'enabled' must be a boolean.");
+	}
+
+	if (typeof every !== "string") {
+		throw new Error("Invalid heartbeat config: 'every' must be a string.");
+	}
+
+	if (model !== null && model !== undefined && typeof model !== "string") {
+		throw new Error("Invalid heartbeat config: 'model' must be a string or null.");
+	}
+
+	return {
+		enabled,
+		every,
+		model: model == null ? null : model,
+	};
 }
 
 // ─── WebChannel ────────────────────────────────────────────────────────────────
@@ -682,6 +725,21 @@ export class WebChannel implements Channel {
 		return `${message}${suffix}`;
 	}
 
+	private getSessionCwd(session: AgentSession): string {
+		const maybeSessionWithCwd = session as AgentSession & { cwd?: string };
+		return maybeSessionWithCwd.cwd ?? process.cwd();
+	}
+
+	private getHeartbeatExtensionPath(session: AgentSession, requestedPath: string): string | undefined {
+		const extensions = session.resourceLoader.getExtensions().extensions as ExtensionDescriptor[];
+		const byPath = extensions.find((ext) => ext.path === requestedPath);
+		if (byPath && isHeartbeatExtension(byPath)) {
+			return byPath.path;
+		}
+		const heartbeatExtension = extensions.find((ext) => isHeartbeatExtension(ext));
+		return heartbeatExtension?.path;
+	}
+
 	private async executeCommand(sessionId: string, session: AgentSession, command: RpcCommand): Promise<RpcResponse> {
 		const id = command.id;
 
@@ -964,9 +1022,14 @@ export class WebChannel implements Channel {
 
 			case "get_extensions": {
 				const extensionsResult = session.resourceLoader.getExtensions();
+				const cwd = this.getSessionCwd(session);
 				const extensions = extensionsResult.extensions
 					.map((ext) => {
-						const uiSpec = resolveExtensionUiSpec(ext as ExtensionDescriptor);
+						const descriptor = ext as ExtensionDescriptor;
+						const uiSpec = resolveExtensionUiSpec(descriptor);
+						const uiState = isHeartbeatExtension(descriptor)
+							? { heartbeat: getHeartbeatUiConfig(cwd), extensionPath: ext.path }
+							: undefined;
 						return {
 							path: ext.path,
 							resolvedPath: ext.resolvedPath,
@@ -975,6 +1038,7 @@ export class WebChannel implements Channel {
 							flags: Array.from(ext.flags.keys()),
 							shortcuts: Array.from(ext.shortcuts.keys()),
 							uiSpec,
+							uiState,
 						};
 					})
 					.filter((ext) => !ext.path.startsWith("<inline:") || Boolean(ext.uiSpec));
@@ -987,6 +1051,60 @@ export class WebChannel implements Channel {
 					data: {
 						extensions,
 						errors: extensionsResult.errors,
+					},
+				};
+			}
+
+			case "get_extension_config": {
+				const heartbeatPath = this.getHeartbeatExtensionPath(session, command.extensionPath);
+				if (!heartbeatPath) {
+					return {
+						id,
+						type: "response",
+						command: "get_extension_config",
+						success: false,
+						error: `Unsupported extension config: ${command.extensionPath}`,
+					};
+				}
+
+				const cwd = this.getSessionCwd(session);
+				const config = getHeartbeatUiConfig(cwd);
+				return {
+					id,
+					type: "response",
+					command: "get_extension_config",
+					success: true,
+					data: {
+						extensionPath: heartbeatPath,
+						config,
+					},
+				};
+			}
+
+			case "set_extension_config": {
+				const heartbeatPath = this.getHeartbeatExtensionPath(session, command.extensionPath);
+				if (!heartbeatPath) {
+					return {
+						id,
+						type: "response",
+						command: "set_extension_config",
+						success: false,
+						error: `Unsupported extension config: ${command.extensionPath}`,
+					};
+				}
+
+				const nextConfig = normalizeHeartbeatConfigInput(command.config);
+				const cwd = this.getSessionCwd(session);
+				const savedConfig = setHeartbeatUiConfig(cwd, nextConfig);
+				reloadSharedHeartbeatRunnerSettings(cwd);
+				return {
+					id,
+					type: "response",
+					command: "set_extension_config",
+					success: true,
+					data: {
+						extensionPath: heartbeatPath,
+						config: savedConfig,
 					},
 				};
 			}

--- a/src/extensions/heartbeat/index.ts
+++ b/src/extensions/heartbeat/index.ts
@@ -11,6 +11,16 @@ function ensureRunner(cwd: string): HeartbeatRunner {
 	return sharedRunner;
 }
 
+export function reloadSharedHeartbeatRunnerSettings(cwd?: string): void {
+	if (!sharedRunner) {
+		return;
+	}
+	if (cwd) {
+		ensureRunner(cwd);
+	}
+	sharedRunner.reloadSettings();
+}
+
 async function handleHeartbeatCommand(args: string, _pi: ExtensionAPI, cwd: string): Promise<string> {
 	const runner = ensureRunner(cwd);
 	const action = args.trim().toLowerCase();

--- a/src/extensions/heartbeat/settings.ts
+++ b/src/extensions/heartbeat/settings.ts
@@ -1,5 +1,6 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { SettingsManager } from "@mariozechner/pi-coding-agent";
 import { getAgentDir, loadConfig } from "../../config.ts";
 import type { HeartbeatSettings } from "./types.ts";
@@ -14,6 +15,14 @@ const DEFAULTS: HeartbeatSettings = {
 	showOk: false,
 	model: null,
 };
+
+const PROJECT_SETTINGS_PATH = [".pi", "settings.json"] as const;
+
+export interface HeartbeatUiConfig {
+	enabled: boolean;
+	every: string;
+	model: string | null;
+}
 
 function toRecord(value: unknown): Record<string, unknown> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -78,4 +87,80 @@ export function resolveHeartbeatSettings(cwd: string): HeartbeatSettings {
 	} catch {
 		return { ...DEFAULTS };
 	}
+}
+
+function getProjectSettingsPath(cwd: string): string {
+	return join(cwd, ...PROJECT_SETTINGS_PATH);
+}
+
+function readProjectSettings(cwd: string): Record<string, unknown> {
+	const settingsPath = getProjectSettingsPath(cwd);
+	if (!existsSync(settingsPath)) {
+		return {};
+	}
+
+	try {
+		const content = readFileSync(settingsPath, "utf8");
+		const parsed = JSON.parse(content);
+		return toRecord(parsed);
+	} catch {
+		return {};
+	}
+}
+
+function writeProjectSettings(cwd: string, settings: Record<string, unknown>): void {
+	const settingsPath = getProjectSettingsPath(cwd);
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+}
+
+function normalizeEvery(value: string): string {
+	const normalized = value.trim().toLowerCase();
+	if (!/^\d+\s*[mh]$/.test(normalized)) {
+		throw new Error("Invalid heartbeat schedule. Use values like '15m' or '1h'.");
+	}
+	return normalized.replace(/\s+/g, "");
+}
+
+function normalizeModel(value: string | null | undefined): string | null {
+	if (value == null) {
+		return null;
+	}
+	const normalized = value.trim();
+	if (!normalized) {
+		return null;
+	}
+	if (!/^[^/]+\/[^/]+$/.test(normalized)) {
+		throw new Error("Invalid model format. Use 'provider/model'.");
+	}
+	return normalized;
+}
+
+export function getHeartbeatUiConfig(cwd: string): HeartbeatUiConfig {
+	const settings = resolveHeartbeatSettings(cwd);
+	return {
+		enabled: settings.enabled,
+		every: settings.every,
+		model: settings.model,
+	};
+}
+
+export function setHeartbeatUiConfig(cwd: string, config: HeartbeatUiConfig): HeartbeatUiConfig {
+	const projectSettings = readProjectSettings(cwd);
+	const currentNamespace = toRecord(projectSettings["clankie-heartbeat"]);
+
+	const nextNamespace = {
+		...currentNamespace,
+		enabled: config.enabled,
+		every: normalizeEvery(config.every),
+		model: normalizeModel(config.model),
+	};
+
+	const nextProjectSettings = {
+		...projectSettings,
+		"clankie-heartbeat": nextNamespace,
+	};
+
+	writeProjectSettings(cwd, nextProjectSettings);
+	return getHeartbeatUiConfig(cwd);
 }

--- a/src/extensions/heartbeat/ui-spec.ts
+++ b/src/extensions/heartbeat/ui-spec.ts
@@ -5,7 +5,7 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 			type: "Card",
 			props: {
 				title: "Heartbeat",
-				description: "Periodic health checks for your workspace",
+				description: "Configure periodic workspace health checks",
 			},
 			children: ["heartbeat-stack"],
 		},
@@ -13,28 +13,64 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 			type: "Stack",
 			props: {
 				direction: "vertical",
-				gap: "sm",
+				gap: "md",
 			},
-			children: ["heartbeat-description", "heartbeat-commands", "heartbeat-flags"],
+			children: [
+				"heartbeat-enabled",
+				"heartbeat-every",
+				"heartbeat-model",
+				"heartbeat-save",
+				"heartbeat-help",
+			],
 		},
-		"heartbeat-description": {
+		"heartbeat-enabled": {
+			type: "Switch",
+			props: {
+				label: "Enable heartbeat",
+				name: "heartbeat-enabled",
+				checked: { $bindState: "/heartbeat/enabled" },
+			},
+		},
+		"heartbeat-every": {
+			type: "Input",
+			props: {
+				label: "Schedule",
+				name: "heartbeat-every",
+				placeholder: "30m",
+				value: { $bindState: "/heartbeat/every" },
+			},
+		},
+		"heartbeat-model": {
+			type: "Input",
+			props: {
+				label: "Model (optional)",
+				name: "heartbeat-model",
+				placeholder: "anthropic/claude-sonnet-4-5",
+				value: { $bindState: "/heartbeat/model" },
+			},
+		},
+		"heartbeat-save": {
+			type: "Button",
+			props: {
+				label: "Save heartbeat settings",
+				variant: "primary",
+			},
+			on: {
+				press: {
+					action: "saveExtensionConfig",
+					params: {
+						enabled: { $state: "/heartbeat/enabled" },
+						every: { $state: "/heartbeat/every" },
+						model: { $state: "/heartbeat/model" },
+					},
+				},
+			},
+		},
+		"heartbeat-help": {
 			type: "Text",
 			props: {
-				text: "Use /heartbeat on|off|run|reload to control checks and --heartbeat to auto-start.",
+				text: "Use values like 15m or 1h. Keep model empty to use the default session model.",
 				variant: "muted",
-			},
-		},
-		"heartbeat-commands": {
-			type: "Text",
-			props: {
-				text: "Commands: /heartbeat on, /heartbeat off, /heartbeat run, /heartbeat reload",
-			},
-		},
-		"heartbeat-flags": {
-			type: "Badge",
-			props: {
-				text: "--heartbeat",
-				variant: "secondary",
 			},
 		},
 	},

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -258,6 +258,29 @@ export class ClankieClient {
     }
   }
 
+  async getExtensionConfig(
+    sessionId: string,
+    extensionPath: string,
+  ): Promise<{ extensionPath: string; config: Record<string, unknown> }> {
+    const response = await this.sendCommand(
+      { type: 'get_extension_config', extensionPath },
+      sessionId,
+    )
+    return response as { extensionPath: string; config: Record<string, unknown> }
+  }
+
+  async setExtensionConfig(
+    sessionId: string,
+    extensionPath: string,
+    config: Record<string, unknown>,
+  ): Promise<{ extensionPath: string; config: Record<string, unknown> }> {
+    const response = await this.sendCommand(
+      { type: 'set_extension_config', extensionPath, config },
+      sessionId,
+    )
+    return response as { extensionPath: string; config: Record<string, unknown> }
+  }
+
   async getSkills(sessionId: string): Promise<{
     skills: Array<{
       name: string

--- a/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
+++ b/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
@@ -5,20 +5,65 @@ import {
   shadcnComponentDefinitions,
   shadcnComponents,
 } from '@json-render/shadcn'
+import { clientManager } from '@/lib/client-manager'
 import type { ExtensionUISpec } from './types'
 
 const catalog = defineCatalog(schema, {
   components: shadcnComponentDefinitions,
-  actions: {},
+  actions: {
+    saveExtensionConfig: {
+      description: 'Save extension configuration',
+    },
+  },
 })
 
 const { registry } = defineRegistry(catalog, {
   components: shadcnComponents,
+  actions: {
+    saveExtensionConfig: async () => {},
+  },
 })
 
-export function JsonRenderRenderer({ spec }: { spec: ExtensionUISpec }) {
+interface JsonRenderRendererProps {
+  spec: ExtensionUISpec
+  sessionId?: string
+  extensionPath?: string
+  initialState?: Record<string, unknown>
+  onConfigSaved?: () => Promise<void> | void
+}
+
+export function JsonRenderRenderer({
+  spec,
+  sessionId,
+  extensionPath,
+  initialState,
+  onConfigSaved,
+}: JsonRenderRendererProps) {
+  const client = clientManager.getClient()
+
   return (
-    <JSONUIProvider registry={registry}>
+    <JSONUIProvider
+      registry={registry}
+      initialState={initialState}
+      handlers={{
+        saveExtensionConfig: async (params) => {
+          if (!client || !sessionId || !extensionPath) {
+            throw new Error('Not connected')
+          }
+
+          await client.setExtensionConfig(sessionId, extensionPath, {
+            enabled: Boolean(params.enabled),
+            every: String(params.every ?? ''),
+            model:
+              typeof params.model === 'string' && params.model.trim() === ''
+                ? null
+                : (params.model ?? null),
+          })
+
+          await onConfigSaved?.()
+        },
+      }}
+    >
       <Renderer spec={spec as any} registry={registry} />
     </JSONUIProvider>
   )

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -73,6 +73,13 @@ export type RpcCommand =
   | { id?: string; type: 'get_messages' }
   | { id?: string; type: 'get_commands' }
   | { id?: string; type: 'get_extensions' }
+  | { id?: string; type: 'get_extension_config'; extensionPath: string }
+  | {
+      id?: string
+      type: 'set_extension_config'
+      extensionPath: string
+      config: Record<string, unknown>
+    }
   | { id?: string; type: 'get_skills' }
   | { id?: string; type: 'install_package'; source: string; local?: boolean }
   | { id?: string; type: 'reload' }
@@ -399,6 +406,7 @@ export interface ExtensionInfo {
   flags: Array<string>
   shortcuts: Array<string>
   uiSpec?: ExtensionUISpec
+  uiState?: Record<string, unknown>
 }
 
 export interface ExtensionError {

--- a/web-ui/src/routes/extensions.tsx
+++ b/web-ui/src/routes/extensions.tsx
@@ -299,7 +299,13 @@ function ExtensionsPage() {
                           <p className="mb-2 text-xs font-medium text-muted-foreground">
                             Extension UI
                           </p>
-                          <JsonRenderRenderer spec={ext.uiSpec} />
+                          <JsonRenderRenderer
+                            spec={ext.uiSpec}
+                            sessionId={activeSessionId ?? undefined}
+                            extensionPath={ext.path}
+                            initialState={ext.uiState}
+                            onConfigSaved={loadExtensionsAndSkills}
+                          />
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
## Summary
- turn heartbeat `uiSpec` into a real config form (enabled, schedule, model)
- add backend RPC commands:
  - `get_extension_config`
  - `set_extension_config`
- persist heartbeat config in project `.pi/settings.json` under `clankie-heartbeat`
- reload shared heartbeat runner settings after save so updates apply immediately
- pass `uiState` with `get_extensions` for heartbeat so form starts with current values
- wire json-render action handler (`saveExtensionConfig`) to call backend save API

## Validation
- `web-ui`: `bun run typecheck` ✅
- root `bun run typecheck` is unavailable (no script)
- root `bun run check` still fails due pre-existing repo-wide formatting/lint issues unrelated to this patch
