### PR TITLE
fix: show toast for extension config save success/error

### DIFF
--- a/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
+++ b/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
@@ -5,6 +5,7 @@ import {
   shadcnComponentDefinitions,
   shadcnComponents,
 } from '@json-render/shadcn'
+import { toast } from 'sonner'
 import { clientManager } from '@/lib/client-manager'
 import type { ExtensionUISpec } from './types'
 
@@ -48,22 +49,30 @@ export function JsonRenderRenderer({
       handlers={{
         saveExtensionConfig: async (params) => {
           if (!client || !sessionId || !extensionPath) {
-            throw new Error('Not connected')
+            toast.error('Not connected')
+            return
           }
 
           const modelValue =
             typeof params.model === 'string' ? params.model.trim() : ''
 
-          await client.setExtensionConfig(sessionId, extensionPath, {
-            enabled: Boolean(params.enabled),
-            every: String(params.every ?? ''),
-            model:
-              modelValue === '' || modelValue === '(default session model)'
-                ? null
-                : modelValue,
-          })
+          try {
+            await client.setExtensionConfig(sessionId, extensionPath, {
+              enabled: Boolean(params.enabled),
+              every: String(params.every ?? ''),
+              model:
+                modelValue === '' || modelValue === '(default session model)'
+                  ? null
+                  : modelValue,
+            })
 
-          await onConfigSaved?.()
+            await onConfigSaved?.()
+            toast.success('Extension settings saved')
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error)
+            toast.error(message)
+          }
         },
       }}
     >

--- a/web-ui/src/routes/__root.tsx
+++ b/web-ui/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@/components/ui/sidebar'
+import { Toaster } from '@/components/ui/sonner'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { clientManager } from '@/lib/client-manager'
 import { connectionStore, updateConnectionSettings } from '@/stores/connection'
@@ -90,6 +91,7 @@ function RootComponent() {
           </SidebarInset>
           <ExtensionUIProvider />
         </SidebarProvider>
+        <Toaster />
       </TooltipProvider>
     </RootDocument>
   )


### PR DESCRIPTION
## Summary\n- mount global  in root layout\n- update extension config save action to show toast notifications\n  - success: \n  - error: backend error message (e.g. invalid heartbeat schedule)\n- prevent uncaught promise errors by handling save failures inside the action handler\n\n## Validation\n- :  ✅\n- root  unavailable (script missing)\n- root The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 227.
Checked 129 files in 42ms. No fixes applied.
Found 174 errors.
Found 72 warnings.
Found 1 info. fails due pre-existing repo-wide lint/format issues unrelated to this fix\n