### PR TITLE
Decouple extension UI actions from hardcoded renderer

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -10,9 +10,9 @@
  */
 
 import * as crypto from "node:crypto";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import type { Server } from "node:http";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
@@ -22,11 +22,6 @@ import { Hono } from "hono";
 import type { WSContext } from "hono/ws";
 import { buildApiKeyProviders } from "../auth/providers.ts";
 import { getAppDir, getAuthPath, loadConfig } from "../config.ts";
-import {
-	getHeartbeatUiConfig,
-	setHeartbeatUiConfig,
-	type HeartbeatUiConfig,
-} from "../extensions/heartbeat/settings.ts";
 import { reloadSharedHeartbeatRunnerSettings } from "../extensions/heartbeat/index.ts";
 import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
 import { getOrCreateSession } from "../sessions.ts";
@@ -97,6 +92,13 @@ type RpcCommand =
 			extensionPath: string;
 			config: Record<string, unknown>;
 	  }
+	| {
+			id?: string;
+			type: "extension_ui_action";
+			extensionPath: string;
+			action: string;
+			params: Record<string, unknown>;
+	  }
 	| { id?: string; type: "get_skills" }
 	| { id?: string; type: "install_package"; source: string; local?: boolean }
 	| { id?: string; type: "reload" }
@@ -154,6 +156,7 @@ type RpcExtensionUIResponse =
 interface ExtensionUISpec {
 	root: string;
 	elements: Record<string, unknown>;
+	actions?: Record<string, { description?: string }>;
 }
 
 interface ExtensionDescriptor {
@@ -174,7 +177,15 @@ function isValidExtensionUISpec(value: unknown): value is ExtensionUISpec {
 		return false;
 	}
 
-	return typeof value.root === "string" && isRecord(value.elements);
+	if (typeof value.root !== "string" || !isRecord(value.elements)) {
+		return false;
+	}
+
+	if (value.actions !== undefined && !isRecord(value.actions)) {
+		return false;
+	}
+
+	return true;
 }
 
 function tryReadJson(filePath: string): unknown | undefined {
@@ -270,28 +281,98 @@ function isHeartbeatExtension(ext: ExtensionDescriptor): boolean {
 	return commandNames.includes("heartbeat") || flagNames.includes("heartbeat");
 }
 
-function normalizeHeartbeatConfigInput(config: Record<string, unknown>): HeartbeatUiConfig {
-	const enabled = config.enabled;
-	const every = config.every;
-	const model = config.model;
+const PROJECT_SETTINGS_PATH = [".pi", "settings.json"] as const;
 
-	if (typeof enabled !== "boolean") {
-		throw new Error("Invalid heartbeat config: 'enabled' must be a boolean.");
+function getProjectSettingsPath(cwd: string): string {
+	return join(cwd, ...PROJECT_SETTINGS_PATH);
+}
+
+function readProjectSettings(cwd: string): Record<string, unknown> {
+	const settingsPath = getProjectSettingsPath(cwd);
+	if (!existsSync(settingsPath)) {
+		return {};
 	}
 
-	if (typeof every !== "string") {
-		throw new Error("Invalid heartbeat config: 'every' must be a string.");
+	try {
+		const content = readFileSync(settingsPath, "utf8");
+		const parsed = JSON.parse(content);
+		return isRecord(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function writeProjectSettings(cwd: string, settings: Record<string, unknown>): void {
+	const settingsPath = getProjectSettingsPath(cwd);
+	mkdirSync(dirname(settingsPath), { recursive: true });
+	writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+}
+
+function sanitizeNamespace(input: string): string {
+	return input
+		.toLowerCase()
+		.replace(/^@/, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.replace(/-{2,}/g, "-");
+}
+
+function getExtensionNamespace(ext: ExtensionDescriptor): string {
+	if (isHeartbeatExtension(ext)) {
+		return "clankie-heartbeat";
 	}
 
-	if (model !== null && model !== undefined && typeof model !== "string") {
-		throw new Error("Invalid heartbeat config: 'model' must be a string or null.");
+	const fromPath = sanitizeNamespace(ext.path);
+	if (fromPath) {
+		return fromPath;
 	}
 
+	return sanitizeNamespace(basename(ext.resolvedPath)) || "extension-config";
+}
+
+function normalizeExtensionUiConfig(namespace: string, config: Record<string, unknown>): Record<string, unknown> {
+	if (namespace !== "clankie-heartbeat") {
+		return config;
+	}
+
+	const model = typeof config.model === "string" ? config.model.trim() : config.model;
 	return {
-		enabled,
-		every,
-		model: model == null ? null : model,
+		enabled: Boolean(config.enabled),
+		every: String(config.every ?? ""),
+		model: model === "" || model === "(default session model)" || model == null ? null : model,
 	};
+}
+
+function getExtensionUiConfig(cwd: string, ext: ExtensionDescriptor): Record<string, unknown> {
+	const settings = readProjectSettings(cwd);
+	const namespace = getExtensionNamespace(ext);
+	const namespaceValue = settings[namespace];
+	return isRecord(namespaceValue) ? namespaceValue : {};
+}
+
+function setExtensionUiConfig(
+	cwd: string,
+	ext: ExtensionDescriptor,
+	config: Record<string, unknown>,
+): Record<string, unknown> {
+	const settings = readProjectSettings(cwd);
+	const namespace = getExtensionNamespace(ext);
+	const nextConfig = normalizeExtensionUiConfig(namespace, config);
+	const currentNamespaceValue = settings[namespace];
+	const currentNamespaceConfig = isRecord(currentNamespaceValue) ? currentNamespaceValue : {};
+	settings[namespace] = {
+		...currentNamespaceConfig,
+		...nextConfig,
+	};
+	writeProjectSettings(cwd, settings);
+	const saved = settings[namespace];
+	return isRecord(saved) ? saved : {};
+}
+
+function applyExtensionConfigSideEffects(cwd: string, ext: ExtensionDescriptor): void {
+	if (isHeartbeatExtension(ext)) {
+		reloadSharedHeartbeatRunnerSettings(cwd);
+	}
 }
 
 // ─── WebChannel ────────────────────────────────────────────────────────────────
@@ -730,14 +811,9 @@ export class WebChannel implements Channel {
 		return maybeSessionWithCwd.cwd ?? process.cwd();
 	}
 
-	private getHeartbeatExtensionPath(session: AgentSession, requestedPath: string): string | undefined {
+	private getExtensionDescriptor(session: AgentSession, requestedPath: string): ExtensionDescriptor | undefined {
 		const extensions = session.resourceLoader.getExtensions().extensions as ExtensionDescriptor[];
-		const byPath = extensions.find((ext) => ext.path === requestedPath);
-		if (byPath && isHeartbeatExtension(byPath)) {
-			return byPath.path;
-		}
-		const heartbeatExtension = extensions.find((ext) => isHeartbeatExtension(ext));
-		return heartbeatExtension?.path;
+		return extensions.find((ext) => ext.path === requestedPath || ext.resolvedPath === requestedPath);
 	}
 
 	private async executeCommand(sessionId: string, session: AgentSession, command: RpcCommand): Promise<RpcResponse> {
@@ -1032,16 +1108,19 @@ export class WebChannel implements Channel {
 					.map((ext) => {
 						const descriptor = ext as ExtensionDescriptor;
 						const uiSpec = resolveExtensionUiSpec(descriptor);
-						const heartbeatConfig = getHeartbeatUiConfig(cwd);
-						const uiState = isHeartbeatExtension(descriptor)
+						const config = getExtensionUiConfig(cwd, descriptor);
+						const uiState = uiSpec
 							? {
-									heartbeat: {
-										...heartbeatConfig,
-										model: heartbeatConfig.model ?? "(default session model)",
+									config: {
+										...config,
+										model:
+											typeof config.model === "string" && config.model.trim().length > 0
+												? config.model
+												: "(default session model)",
 									},
 									availableModels: availableModelIds,
 									extensionPath: ext.path,
-							  }
+								}
 							: undefined;
 						return {
 							path: ext.path,
@@ -1069,54 +1148,81 @@ export class WebChannel implements Channel {
 			}
 
 			case "get_extension_config": {
-				const heartbeatPath = this.getHeartbeatExtensionPath(session, command.extensionPath);
-				if (!heartbeatPath) {
+				const extension = this.getExtensionDescriptor(session, command.extensionPath);
+				if (!extension) {
 					return {
 						id,
 						type: "response",
 						command: "get_extension_config",
 						success: false,
-						error: `Unsupported extension config: ${command.extensionPath}`,
+						error: `Unknown extension: ${command.extensionPath}`,
 					};
 				}
 
 				const cwd = this.getSessionCwd(session);
-				const config = getHeartbeatUiConfig(cwd);
+				const config = getExtensionUiConfig(cwd, extension);
 				return {
 					id,
 					type: "response",
 					command: "get_extension_config",
 					success: true,
 					data: {
-						extensionPath: heartbeatPath,
+						extensionPath: extension.path,
 						config,
 					},
 				};
 			}
 
 			case "set_extension_config": {
-				const heartbeatPath = this.getHeartbeatExtensionPath(session, command.extensionPath);
-				if (!heartbeatPath) {
+				const extension = this.getExtensionDescriptor(session, command.extensionPath);
+				if (!extension) {
 					return {
 						id,
 						type: "response",
 						command: "set_extension_config",
 						success: false,
-						error: `Unsupported extension config: ${command.extensionPath}`,
+						error: `Unknown extension: ${command.extensionPath}`,
 					};
 				}
 
-				const nextConfig = normalizeHeartbeatConfigInput(command.config);
 				const cwd = this.getSessionCwd(session);
-				const savedConfig = setHeartbeatUiConfig(cwd, nextConfig);
-				reloadSharedHeartbeatRunnerSettings(cwd);
+				const savedConfig = setExtensionUiConfig(cwd, extension, command.config);
+				applyExtensionConfigSideEffects(cwd, extension);
 				return {
 					id,
 					type: "response",
 					command: "set_extension_config",
 					success: true,
 					data: {
-						extensionPath: heartbeatPath,
+						extensionPath: extension.path,
+						config: savedConfig,
+					},
+				};
+			}
+
+			case "extension_ui_action": {
+				const extension = this.getExtensionDescriptor(session, command.extensionPath);
+				if (!extension) {
+					return {
+						id,
+						type: "response",
+						command: "extension_ui_action",
+						success: false,
+						error: `Unknown extension: ${command.extensionPath}`,
+					};
+				}
+
+				const cwd = this.getSessionCwd(session);
+				const savedConfig = setExtensionUiConfig(cwd, extension, command.params);
+				applyExtensionConfigSideEffects(cwd, extension);
+				return {
+					id,
+					type: "response",
+					command: "extension_ui_action",
+					success: true,
+					data: {
+						extensionPath: extension.path,
+						action: command.action,
 						config: savedConfig,
 					},
 				};

--- a/src/extensions/heartbeat/ui-spec.ts
+++ b/src/extensions/heartbeat/ui-spec.ts
@@ -15,20 +15,14 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 				direction: "vertical",
 				gap: "md",
 			},
-			children: [
-				"heartbeat-enabled",
-				"heartbeat-every",
-				"heartbeat-model",
-				"heartbeat-save",
-				"heartbeat-help",
-			],
+			children: ["heartbeat-enabled", "heartbeat-every", "heartbeat-model", "heartbeat-save", "heartbeat-help"],
 		},
 		"heartbeat-enabled": {
 			type: "Switch",
 			props: {
 				label: "Enable heartbeat",
 				name: "heartbeat-enabled",
-				checked: { $bindState: "/heartbeat/enabled" },
+				checked: { $bindState: "/config/enabled" },
 			},
 		},
 		"heartbeat-every": {
@@ -37,7 +31,7 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 				label: "Schedule",
 				name: "heartbeat-every",
 				placeholder: "30m",
-				value: { $bindState: "/heartbeat/every" },
+				value: { $bindState: "/config/every" },
 			},
 		},
 		"heartbeat-model": {
@@ -46,7 +40,7 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 				label: "Model (optional)",
 				name: "heartbeat-model",
 				options: { $state: "/availableModels" },
-				value: { $bindState: "/heartbeat/model" },
+				value: { $bindState: "/config/model" },
 			},
 		},
 		"heartbeat-save": {
@@ -59,9 +53,9 @@ export const HEARTBEAT_EXTENSION_UI_SPEC = {
 				press: {
 					action: "saveExtensionConfig",
 					params: {
-						enabled: { $state: "/heartbeat/enabled" },
-						every: { $state: "/heartbeat/every" },
-						model: { $state: "/heartbeat/model" },
+						enabled: { $state: "/config/enabled" },
+						every: { $state: "/config/every" },
+						model: { $state: "/config/model" },
 					},
 				},
 			},

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -287,6 +287,27 @@ export class ClankieClient {
     }
   }
 
+  async extensionUIAction(
+    sessionId: string,
+    extensionPath: string,
+    action: string,
+    params: Record<string, unknown>,
+  ): Promise<{
+    extensionPath: string
+    action: string
+    config: Record<string, unknown>
+  }> {
+    const response = await this.sendCommand(
+      { type: 'extension_ui_action', extensionPath, action, params },
+      sessionId,
+    )
+    return response as {
+      extensionPath: string
+      action: string
+      config: Record<string, unknown>
+    }
+  }
+
   async getSkills(sessionId: string): Promise<{
     skills: Array<{
       name: string

--- a/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
+++ b/web-ui/src/lib/tool-renderers/json-render-renderer.tsx
@@ -1,82 +1,103 @@
-import { defineCatalog } from '@json-render/core'
-import { JSONUIProvider, Renderer, defineRegistry } from '@json-render/react'
-import { schema } from '@json-render/react/schema'
-import {
-  shadcnComponentDefinitions,
-  shadcnComponents,
-} from '@json-render/shadcn'
-import { toast } from 'sonner'
-import type { ExtensionUISpec } from './types'
-import { clientManager } from '@/lib/client-manager'
+import { defineCatalog } from "@json-render/core";
+import { JSONUIProvider, Renderer, defineRegistry } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
+import { shadcnComponentDefinitions, shadcnComponents } from "@json-render/shadcn";
+import { useMemo } from "react";
+import { toast } from "sonner";
+import { clientManager } from "@/lib/client-manager";
+import type { ExtensionUISpec } from "./types";
 
 const catalog = defineCatalog(schema, {
-  components: shadcnComponentDefinitions,
-  actions: {
-    saveExtensionConfig: {
-      description: 'Save extension configuration',
-    },
-  },
-})
+	components: shadcnComponentDefinitions,
+	actions: {},
+});
 
 const { registry } = defineRegistry(catalog, {
-  components: shadcnComponents,
-  actions: {
-    saveExtensionConfig: async () => {},
-  },
-})
+	components: shadcnComponents,
+});
 
 interface JsonRenderRendererProps {
-  spec: ExtensionUISpec
-  sessionId?: string
-  extensionPath?: string
-  initialState?: Record<string, unknown>
-  onConfigSaved?: () => Promise<void> | void
+	spec: ExtensionUISpec;
+	sessionId?: string;
+	extensionPath?: string;
+	initialState?: Record<string, unknown>;
+	onConfigSaved?: () => Promise<void> | void;
+}
+
+function collectActionNames(value: unknown, names = new Set<string>()): Set<string> {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			collectActionNames(item, names);
+		}
+		return names;
+	}
+
+	if (!value || typeof value !== "object") {
+		return names;
+	}
+
+	const record = value as Record<string, unknown>;
+	if (typeof record.action === "string" && record.action.trim().length > 0) {
+		names.add(record.action);
+	}
+
+	for (const nested of Object.values(record)) {
+		collectActionNames(nested, names);
+	}
+
+	return names;
 }
 
 export function JsonRenderRenderer({
-  spec,
-  sessionId,
-  extensionPath,
-  initialState,
-  onConfigSaved,
+	spec,
+	sessionId,
+	extensionPath,
+	initialState,
+	onConfigSaved,
 }: JsonRenderRendererProps) {
-  const client = clientManager.getClient()
+	const client = clientManager.getClient();
 
-  return (
-    <JSONUIProvider
-      registry={registry}
-      initialState={initialState}
-      handlers={{
-        saveExtensionConfig: async (params) => {
-          if (!client || !sessionId || !extensionPath) {
-            toast.error('Not connected')
-            return
-          }
+	const actionNames = useMemo(() => {
+		const fromElements = collectActionNames(spec.elements);
+		const fromSpec = Object.keys(spec.actions ?? {});
+		for (const action of fromSpec) {
+			fromElements.add(action);
+		}
+		return Array.from(fromElements);
+	}, [spec.actions, spec.elements]);
 
-          const modelValue =
-            typeof params.model === 'string' ? params.model.trim() : ''
+	const handlers = useMemo(() => {
+		const map: Record<string, (params: Record<string, unknown>) => Promise<unknown>> = {};
 
-          try {
-            await client.setExtensionConfig(sessionId, extensionPath, {
-              enabled: Boolean(params.enabled),
-              every: String(params.every ?? ''),
-              model:
-                modelValue === '' || modelValue === '(default session model)'
-                  ? null
-                  : modelValue,
-            })
+		for (const actionName of actionNames) {
+			map[actionName] = async (params) => {
+				if (!client || !sessionId || !extensionPath) {
+					toast.error("Not connected");
+					return;
+				}
 
-            await onConfigSaved?.()
-            toast.success('Extension settings saved')
-          } catch (error) {
-            const message =
-              error instanceof Error ? error.message : String(error)
-            toast.error(message)
-          }
-        },
-      }}
-    >
-      <Renderer spec={spec as any} registry={registry} />
-    </JSONUIProvider>
-  )
+				try {
+					const result = await client.extensionUIAction(sessionId, extensionPath, actionName, params);
+
+					await onConfigSaved?.();
+					if (actionName.toLowerCase().includes("save")) {
+						toast.success("Extension settings saved");
+					}
+					return result;
+				} catch (error) {
+					const message = error instanceof Error ? error.message : String(error);
+					toast.error(message);
+					throw error;
+				}
+			};
+		}
+
+		return map;
+	}, [actionNames, client, extensionPath, onConfigSaved, sessionId]);
+
+	return (
+		<JSONUIProvider registry={registry} initialState={initialState} handlers={handlers}>
+			<Renderer spec={spec as unknown as Parameters<typeof Renderer>[0]["spec"]} registry={registry} />
+		</JSONUIProvider>
+	);
 }

--- a/web-ui/src/lib/tool-renderers/types.ts
+++ b/web-ui/src/lib/tool-renderers/types.ts
@@ -21,4 +21,5 @@ export interface ExtensionRenderHint {
 export interface ExtensionUISpec {
   root: string
   elements: Record<string, unknown>
+  actions?: Record<string, { description?: string }>
 }

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -80,6 +80,13 @@ export type RpcCommand =
       extensionPath: string
       config: Record<string, unknown>
     }
+  | {
+      id?: string
+      type: 'extension_ui_action'
+      extensionPath: string
+      action: string
+      params: Record<string, unknown>
+    }
   | { id?: string; type: 'get_skills' }
   | { id?: string; type: 'install_package'; source: string; local?: boolean }
   | { id?: string; type: 'reload' }
@@ -396,6 +403,7 @@ export type ExtensionUIResponse =
 export interface ExtensionUISpec {
   root: string
   elements: Record<string, unknown>
+  actions?: Record<string, { description?: string }>
 }
 
 export interface ExtensionInfo {


### PR DESCRIPTION
## Summary\n- add generic  RPC command in \n- replace heartbeat-only extension config handling with generic extension namespace storage in \n- make  UI state generic (, , )\n- keep heartbeat behavior via side-effect hook ()\n- update heartbeat UI spec bindings to use \n- add  method to the web UI client\n- make  discover action names from the UI spec and forward actions generically to backend\n- extend  type to optionally include \n\n## Validation\n- Bundled 1737 modules in 139ms

  cli.js  12.73 MB  (entry point) ✅\n-  ✅\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 237.
Checked 136 files in 82ms. No fixes applied.
Found 182 errors.
Found 74 warnings.
Found 1 info. ❌ (fails due pre-existing formatting/lint issues across the repository unrelated to this PR)\n\n## Notes\nThis removes the need to hardcode extension action handlers in  for each third-party extension.