### PR TITLE
feat(web-ui): add slash command palette to chat input

### DIFF
--- a/web-ui/bun.lock
+++ b/web-ui/bun.lock
@@ -27,6 +27,7 @@
         "@tanstack/store": "^0.9.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.575.0",
         "next-themes": "^0.4.6",
@@ -913,6 +914,8 @@
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -35,6 +35,7 @@
     "@tanstack/store": "^0.9.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.575.0",
     "next-themes": "^0.4.6",

--- a/web-ui/src/components/__tests__/chat-input.test.tsx
+++ b/web-ui/src/components/__tests__/chat-input.test.tsx
@@ -21,11 +21,21 @@ describe('ChatInput', () => {
   const mockClient = {
     prompt: vi.fn(),
     uploadAttachment: vi.fn(),
+    getCommands: vi.fn(),
   }
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockAlert.mockClear()
+    mockClient.getCommands.mockResolvedValue({
+      commands: [
+        {
+          name: 'heartbeat',
+          description: 'Run heartbeat check',
+          source: 'extension',
+        },
+      ],
+    })
     ;(clientManager.getClient as any).mockReturnValue(mockClient)
 
     // Set up a valid session
@@ -56,6 +66,12 @@ describe('ChatInput', () => {
       render(<ChatInput />)
 
       expect(screen.getByTitle('Attach files')).toBeInTheDocument()
+    })
+
+    it('renders insert command button', () => {
+      render(<ChatInput />)
+
+      expect(screen.getByTitle('Insert command')).toBeInTheDocument()
     })
 
     it('renders hidden file input with correct attributes', () => {
@@ -180,6 +196,75 @@ describe('ChatInput', () => {
 
       // Textarea should still have content (Enter adds newline)
       expect(textarea).toHaveValue('Test message\n')
+    })
+  })
+
+  describe('Slash commands', () => {
+    it('shows command palette when typing slash command', async () => {
+      const user = userEvent.setup()
+      render(<ChatInput />)
+
+      const textarea = screen.getByPlaceholderText(/Send a message/i)
+      await user.type(textarea, '/')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+      })
+      expect(mockClient.getCommands).toHaveBeenCalledWith('test-session-123')
+    })
+
+    it('hides command palette when text no longer matches slash trigger', async () => {
+      const user = userEvent.setup()
+      render(<ChatInput />)
+
+      const textarea = screen.getByPlaceholderText(/Send a message/i)
+      await user.type(textarea, '/abc test')
+
+      expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+    })
+
+    it('hides command palette on Escape', async () => {
+      const user = userEvent.setup()
+      render(<ChatInput />)
+
+      const textarea = screen.getByPlaceholderText(/Send a message/i)
+      await user.type(textarea, '/')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+      })
+
+      await user.keyboard('{Escape}')
+
+      expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+    })
+
+    it('inserts selected command into textarea', async () => {
+      const user = userEvent.setup()
+      render(<ChatInput />)
+
+      const textarea = screen.getByPlaceholderText(/Send a message/i)
+      await user.type(textarea, '/')
+
+      const commandItem = await screen.findByText('/heartbeat')
+      await user.click(commandItem)
+
+      expect(textarea).toHaveValue('/heartbeat ')
+      expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+    })
+
+    it('inserts slash and opens palette from toolbar button', async () => {
+      const user = userEvent.setup()
+      render(<ChatInput />)
+
+      await user.click(screen.getByTitle('Insert command'))
+
+      const textarea = screen.getByPlaceholderText(/Send a message/i)
+      expect(textarea).toHaveValue('/')
+
+      await waitFor(() => {
+        expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+      })
     })
   })
 

--- a/web-ui/src/components/__tests__/command-palette.test.tsx
+++ b/web-ui/src/components/__tests__/command-palette.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CommandPalette } from '../command-palette'
+import { clientManager } from '@/lib/client-manager'
+import { sessionStore } from '@/stores/session'
+
+vi.mock('@/lib/client-manager', () => ({
+  clientManager: {
+    getClient: vi.fn(),
+  },
+}))
+
+describe('CommandPalette', () => {
+  const mockGetCommands = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    sessionStore.setState((state) => ({
+      ...state,
+      sessionId: 'test-session-123',
+      isStreaming: false,
+    }))
+
+    mockGetCommands.mockResolvedValue({
+      commands: [
+        {
+          name: 'heartbeat',
+          description: 'Run periodic health checks',
+          source: 'extension',
+        },
+        {
+          name: 'docs',
+          description: 'Open docs prompt template',
+          source: 'prompt',
+        },
+        {
+          name: 'skill:frontend-design',
+          description: 'Build polished frontend UIs',
+          source: 'skill',
+        },
+      ],
+    })
+    ;(clientManager.getClient as any).mockReturnValue({
+      getCommands: mockGetCommands,
+    })
+  })
+
+  it('renders grouped command results', async () => {
+    render(<CommandPalette open search="" onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/heartbeat')).toBeInTheDocument()
+      expect(screen.getByText('/docs')).toBeInTheDocument()
+      expect(screen.getByText('/skill:frontend-design')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Extensions')).toBeInTheDocument()
+    expect(screen.getByText('Prompt Templates')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+  })
+
+  it('filters commands by search term', async () => {
+    render(<CommandPalette open search="heart" onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('/heartbeat')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('/docs')).not.toBeInTheDocument()
+    expect(screen.queryByText('/skill:frontend-design')).not.toBeInTheDocument()
+  })
+
+  it('calls onSelect with command name', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+
+    render(<CommandPalette open search="" onSelect={onSelect} />)
+
+    const item = await screen.findByText('/heartbeat')
+    await user.click(item)
+
+    expect(onSelect).toHaveBeenCalledWith('heartbeat')
+  })
+
+  it('shows empty state when no command matches search', async () => {
+    render(<CommandPalette open search="not-found" onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No commands found.')).toBeInTheDocument()
+    })
+  })
+})

--- a/web-ui/src/components/chat-input.tsx
+++ b/web-ui/src/components/chat-input.tsx
@@ -1,11 +1,12 @@
 import { useStore } from '@tanstack/react-store'
-import { Paperclip, Send } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { Paperclip, Send, Slash } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ClipboardEvent, DragEvent, KeyboardEvent } from 'react'
 import type { AttachmentItem } from '@/components/attachment-preview'
 import type { ImageContent } from '@/lib/types'
 import type { DisplayAttachment } from '@/stores/messages'
 import { AttachmentPreview } from '@/components/attachment-preview'
+import { CommandPalette } from '@/components/command-palette'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { clientManager } from '@/lib/client-manager'
@@ -14,6 +15,7 @@ import { sessionStore } from '@/stores/session'
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB per file
 const MAX_TOTAL_SIZE = 20 * 1024 * 1024 // 20MB total
+const COMMAND_TRIGGER_REGEX = /^\/\S*$/
 
 export function ChatInput() {
   const { sessionId, isStreaming } = useStore(sessionStore, (state) => ({
@@ -24,9 +26,33 @@ export function ChatInput() {
   const [message, setMessage] = useState('')
   const [attachments, setAttachments] = useState<Array<AttachmentItem>>([])
   const [isDragging, setIsDragging] = useState(false)
+  const [isCommandPaletteDismissed, setIsCommandPaletteDismissed] =
+    useState(false)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const inputDockRef = useRef<HTMLDivElement>(null)
+
+  const isCommandMode = COMMAND_TRIGGER_REGEX.test(message)
+  const commandSearch = isCommandMode ? message.slice(1) : ''
+  const showCommandPalette =
+    isCommandMode && !isCommandPaletteDismissed && !!sessionId && !isStreaming
+
+  useEffect(() => {
+    if (!showCommandPalette) return
+
+    const handlePointerDownOutside = (event: MouseEvent) => {
+      if (!inputDockRef.current) return
+      if (!inputDockRef.current.contains(event.target as Node)) {
+        setIsCommandPaletteDismissed(true)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDownOutside)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDownOutside)
+    }
+  }, [showCommandPalette])
 
   // Convert File to base64
   const fileToBase64 = useCallback((file: File): Promise<string> => {
@@ -175,6 +201,23 @@ export function ChatInput() {
     [addFiles],
   )
 
+  const handleMessageChange = (value: string) => {
+    setMessage(value)
+    setIsCommandPaletteDismissed(false)
+  }
+
+  const handleCommandSelect = (commandName: string) => {
+    setMessage(`/${commandName} `)
+    setIsCommandPaletteDismissed(true)
+    textareaRef.current?.focus()
+  }
+
+  const handleInsertSlash = () => {
+    setMessage('/')
+    setIsCommandPaletteDismissed(false)
+    textareaRef.current?.focus()
+  }
+
   // Remove attachment
   const handleRemoveAttachment = useCallback((id: string) => {
     setAttachments((prev) => prev.filter((att) => att.id !== id))
@@ -264,6 +307,12 @@ export function ChatInput() {
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Escape' && showCommandPalette) {
+      e.preventDefault()
+      setIsCommandPaletteDismissed(true)
+      return
+    }
+
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       e.preventDefault()
       handleSend()
@@ -279,7 +328,18 @@ export function ChatInput() {
     >
       <div className="mx-auto w-full max-w-3xl">
         {/* Floating dock container */}
-        <div className="relative rounded-2xl border border-border/40 bg-card/80 backdrop-blur-xl shadow-2xl shadow-black/10 dark:shadow-black/30">
+        <div
+          ref={inputDockRef}
+          className="relative rounded-2xl border border-border/40 bg-card/80 backdrop-blur-xl shadow-2xl shadow-black/10 dark:shadow-black/30"
+        >
+          {showCommandPalette && (
+            <CommandPalette
+              open={showCommandPalette}
+              search={commandSearch}
+              onSelect={handleCommandSelect}
+            />
+          )}
+
           {/* Attachment previews */}
           {attachments.length > 0 && (
             <div className="px-4 pt-3">
@@ -297,7 +357,7 @@ export function ChatInput() {
               id="chat-input"
               name="message"
               value={message}
-              onChange={(e) => setMessage(e.target.value)}
+              onChange={(e) => handleMessageChange(e.target.value)}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
               placeholder="Send a message..."
@@ -337,6 +397,18 @@ export function ChatInput() {
               >
                 <Paperclip className="h-4 w-4" />
                 <span className="sr-only">Attach files</span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                disabled={!sessionId || isStreaming}
+                onClick={handleInsertSlash}
+                title="Insert command"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              >
+                <Slash className="h-4 w-4" />
+                <span className="sr-only">Insert command</span>
               </Button>
             </div>
 

--- a/web-ui/src/components/command-palette.tsx
+++ b/web-ui/src/components/command-palette.tsx
@@ -1,0 +1,206 @@
+import { useStore } from '@tanstack/react-store'
+import { Braces, FileCode2, Wrench } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ComponentType } from 'react'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command'
+import { clientManager } from '@/lib/client-manager'
+import { cn } from '@/lib/utils'
+import { sessionStore } from '@/stores/session'
+
+type CommandSource = 'extension' | 'prompt' | 'skill'
+
+interface AvailableCommand {
+  name: string
+  description?: string
+  source: string
+  location?: string
+  path?: string
+}
+
+interface CommandPaletteProps {
+  open: boolean
+  search: string
+  onSelect: (commandName: string) => void
+  className?: string
+}
+
+const SOURCE_ORDER: Array<CommandSource> = ['extension', 'prompt', 'skill']
+
+const SOURCE_LABELS: Record<CommandSource, string> = {
+  extension: 'Extensions',
+  prompt: 'Prompt Templates',
+  skill: 'Skills',
+}
+
+const SOURCE_ICONS: Record<
+  CommandSource,
+  ComponentType<{ className?: string }>
+> = {
+  extension: Wrench,
+  prompt: FileCode2,
+  skill: Braces,
+}
+
+export function CommandPalette({
+  open,
+  search,
+  onSelect,
+  className,
+}: CommandPaletteProps) {
+  const { sessionId } = useStore(sessionStore, (state) => ({
+    sessionId: state.sessionId,
+  }))
+
+  const [commands, setCommands] = useState<Array<AvailableCommand>>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const cacheRef = useRef<Map<string, Array<AvailableCommand>>>(new Map())
+
+  useEffect(() => {
+    if (!open || !sessionId) return
+
+    const cached = cacheRef.current.get(sessionId)
+    if (cached) {
+      setCommands(cached)
+      return
+    }
+
+    const client = clientManager.getClient()
+    if (!client) {
+      setError('No client available')
+      return
+    }
+
+    let isCancelled = false
+
+    setIsLoading(true)
+    setError(null)
+
+    client
+      .getCommands(sessionId)
+      .then((result) => {
+        if (isCancelled) return
+
+        const sorted = [...result.commands].sort((a, b) =>
+          a.name.localeCompare(b.name),
+        )
+
+        cacheRef.current.set(sessionId, sorted)
+        setCommands(sorted)
+      })
+      .catch((err) => {
+        if (isCancelled) return
+        console.error('[CommandPalette] Failed to load commands:', err)
+        setError('Failed to load commands')
+      })
+      .finally(() => {
+        if (isCancelled) return
+        setIsLoading(false)
+      })
+
+    return () => {
+      isCancelled = true
+    }
+  }, [open, sessionId])
+
+  const filteredCommands = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return commands
+
+    return commands.filter((command) => {
+      const nameMatch = command.name.toLowerCase().includes(query)
+      const descriptionMatch =
+        command.description?.toLowerCase().includes(query) ?? false
+      return nameMatch || descriptionMatch
+    })
+  }, [commands, search])
+
+  const commandsBySource = useMemo(() => {
+    const groups = new Map<CommandSource, Array<AvailableCommand>>()
+
+    for (const source of SOURCE_ORDER) {
+      groups.set(source, [])
+    }
+
+    for (const command of filteredCommands) {
+      if (command.source === 'extension') {
+        groups.get('extension')!.push(command)
+      } else if (command.source === 'prompt') {
+        groups.get('prompt')!.push(command)
+      } else if (command.source === 'skill') {
+        groups.get('skill')!.push(command)
+      }
+    }
+
+    return groups
+  }, [filteredCommands])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        'absolute bottom-full left-0 right-0 mb-2 z-40 rounded-xl border border-border/60 bg-popover/95 backdrop-blur-xl shadow-2xl shadow-black/10 dark:shadow-black/30',
+        className,
+      )}
+      data-testid="command-palette"
+    >
+      <Command shouldFilter={false}>
+        <CommandList>
+          {isLoading ? (
+            <CommandEmpty>Loading commands...</CommandEmpty>
+          ) : error ? (
+            <CommandEmpty>{error}</CommandEmpty>
+          ) : (
+            <>
+              <CommandEmpty>No commands found.</CommandEmpty>
+
+              {SOURCE_ORDER.filter(
+                (source) => (commandsBySource.get(source) ?? []).length > 0,
+              ).map((source, index) => {
+                const sourceCommands = commandsBySource.get(source) ?? []
+                const Icon = SOURCE_ICONS[source]
+
+                return (
+                  <div key={source}>
+                    {index > 0 && <CommandSeparator />}
+                    <CommandGroup heading={SOURCE_LABELS[source]}>
+                      {sourceCommands.map((command) => (
+                        <CommandItem
+                          key={`${source}-${command.name}`}
+                          value={command.name}
+                          onSelect={() => onSelect(command.name)}
+                          className="items-start"
+                        >
+                          <Icon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                          <div className="flex min-w-0 flex-col">
+                            <span className="font-medium">/{command.name}</span>
+                            {command.description && (
+                              <span className="text-xs text-muted-foreground line-clamp-2">
+                                {command.description}
+                              </span>
+                            )}
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </div>
+                )
+              })}
+            </>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+  )
+}

--- a/web-ui/src/components/ui/command.tsx
+++ b/web-ui/src/components/ui/command.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { Command as CommandPrimitive } from 'cmdk'
+import { CheckIcon, SearchIcon } from 'lucide-react'
+import type * as React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { InputGroup, InputGroupAddon } from '@/components/ui/input-group'
+import { cn } from '@/lib/utils'
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  className,
+  showCloseButton = false,
+  ...props
+}: Omit<React.ComponentProps<typeof Dialog>, 'children'> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn(
+          'top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0',
+          className,
+        )}
+        showCloseButton={showCloseButton}
+      >
+        {children}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div data-slot="command-input-wrapper" className="p-1 pb-0">
+      <InputGroup className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
+        <CommandPrimitive.Input
+          data-slot="command-input"
+          className={cn(
+            'w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          {...props}
+        />
+        <InputGroupAddon>
+          <SearchIcon className="size-4 shrink-0 opacity-50" />
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        'no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className={cn('py-6 text-center text-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
+    </CommandPrimitive.Item>
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        'ml-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/web-ui/src/components/ui/dialog.tsx
+++ b/web-ui/src/components/ui/dialog.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
+import { XIcon } from 'lucide-react'
+import type * as React from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-base leading-none font-medium', className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        'text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -336,6 +336,27 @@ export class ClankieClient {
     }
   }
 
+  async getCommands(sessionId: string): Promise<{
+    commands: Array<{
+      name: string
+      description?: string
+      source: string
+      location?: string
+      path?: string
+    }>
+  }> {
+    const response = await this.sendCommand({ type: 'get_commands' }, sessionId)
+    return response as {
+      commands: Array<{
+        name: string
+        description?: string
+        source: string
+        location?: string
+        path?: string
+      }>
+    }
+  }
+
   async installPackage(
     sessionId: string,
     source: string,

--- a/web-ui/src/test/setup.ts
+++ b/web-ui/src/test/setup.ts
@@ -24,6 +24,7 @@ const INITIAL_CONNECTION_STATE = {
   settings: {
     url: 'ws://localhost:3100',
     authToken: '',
+    useCookieAuth: false,
   },
   status: 'disconnected' as const,
   error: undefined,
@@ -98,4 +99,11 @@ beforeEach(() => {
   localStorage.clear()
   // Mock scrollIntoView (not implemented in jsdom)
   Element.prototype.scrollIntoView = vi.fn()
+
+  // Mock ResizeObserver (used by cmdk)
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
 })


### PR DESCRIPTION
## Summary
- add shadcn base  and  UI primitives ()
- add  to the web socket client
- add  for listing/filtering Pi + extension commands (grouped by source)
- integrate slash command UX in chat input:
  - open palette when message matches  at start
  - insert selected command as 
  - close on  or outside click
  - add toolbar  button for discoverability
- add tests for  and slash interactions in 
- add  test polyfill for cmdk in test setup

## Validation
-  ✅
-  ✅
- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 247.
Checked 139 files in 61ms. No fixes applied.
Found 188 errors.
Found 78 warnings.
Found 1 info. ⚠️ fails due pre-existing lint errors in unrelated files (, , , , etc.)
