### PR TITLE
fix: remove automatic memory extension registration

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,7 +19,6 @@ import {
 	ModelRegistry,
 	SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import createMemoryExtension from "../extensions/clankie-memory/src/index.ts";
 import { getAgentDir, getAppDir, getAuthPath, getWorkspace, loadConfig } from "./config.ts";
 import { createCronExtension } from "./extensions/cron/index.ts";
 import { createHeartbeatExtension } from "./extensions/heartbeat/index.ts";
@@ -69,7 +68,6 @@ export async function createSession(options: SessionOptions = {}): Promise<Creat
 	const extensionFactories: ExtensionFactory[] = [];
 	extensionFactories.push(createCronExtension());
 	extensionFactories.push(createHeartbeatExtension());
-	extensionFactories.push(createMemoryExtension);
 	const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true; // default: enabled
 	if (restrictToWorkspace) {
 		const configuredAllowedPaths = config.agent?.allowedPaths ?? [];

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -17,7 +17,6 @@ import {
 	ModelRegistry,
 	SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import createMemoryExtension from "../extensions/clankie-memory/src/index.ts";
 import type { Attachment } from "./channels/channel.ts";
 import { type AppConfig, getAgentDir, getAppDir, getAuthPath, getWorkspace } from "./config.ts";
 import { createCronExtension } from "./extensions/cron/index.ts";
@@ -55,7 +54,6 @@ export async function getOrCreateSession(chatKey: string, config: AppConfig): Pr
 	const extensionFactories: ExtensionFactory[] = [];
 	extensionFactories.push(createCronExtension());
 	extensionFactories.push(createHeartbeatExtension());
-	extensionFactories.push(createMemoryExtension);
 	const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true; // default: enabled
 	if (restrictToWorkspace) {
 		const configuredAllowedPaths = config.agent?.allowedPaths ?? [];


### PR DESCRIPTION
The clankie-memory extension should be opt-in, not automatically registered in agent.ts and sessions.ts.

Users who want to use it can enable it via pi's auto-discovery mechanism by adding the extension path to their clankie settings.