### PR TITLE
Fix scoped model persistence and recent session ordering in web UI

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -31,6 +31,7 @@ import { buildApiKeyProviders } from "../auth/providers.ts";
 import { getAppDir, getAuthPath, loadConfig } from "../config.ts";
 import { reloadSharedHeartbeatRunnerSettings } from "../extensions/heartbeat/index.ts";
 import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
+import { resolveScopedModels } from "../lib/scoped-model-resolver.ts";
 import { getOrCreateSession } from "../sessions.ts";
 import type { Channel, MessageHandler } from "./channel.ts";
 
@@ -1471,22 +1472,26 @@ export class WebChannel implements Channel {
 
 			case "set_scoped_models": {
 				// 1. Persist patterns to settings.json
-				const patterns = command.models; // e.g. ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]
+				const patterns = command.models.map((pattern) => pattern.trim()).filter(Boolean);
 				session.settingsManager.setEnabledModels(patterns.length > 0 ? patterns : undefined);
 				await session.settingsManager.flush();
 
 				// 2. Resolve patterns to Model objects and update live session
 				const available = await session.modelRegistry.getAvailable();
-				const resolved = [];
-				for (const pattern of patterns) {
-					const [provider, modelId] = pattern.split("/", 2);
-					const model = available.find((m) => m.provider === provider && m.id === modelId);
-					if (model) resolved.push({ model, thinkingLevel: session.thinkingLevel });
-				}
+				const resolved = resolveScopedModels(patterns, available).map((model) => ({
+					model,
+					thinkingLevel: session.thinkingLevel,
+				}));
 				session.setScopedModels(resolved);
 
-				return { id, type: "response", command: "set_scoped_models", success: true,
-					data: { enabledModels: patterns } };
+				const enabledModels = session.settingsManager.getEnabledModels() ?? [];
+				return {
+					id,
+					type: "response",
+					command: "set_scoped_models",
+					success: true,
+					data: { enabledModels },
+				};
 			}
 
 			default: {
@@ -1877,8 +1882,11 @@ export class WebChannel implements Channel {
 		}
 	}
 
-	private async listAllSessions(): Promise<Array<{ sessionId: string; title?: string; messageCount: number }>> {
-		const sessions: Array<{ sessionId: string; title?: string; messageCount: number }> = [];
+	private async listAllSessions(): Promise<
+		Array<{ sessionId: string; title?: string; messageCount: number; createdAt?: number; updatedAt?: number }>
+	> {
+		const sessions: Array<{ sessionId: string; title?: string; messageCount: number; createdAt?: number; updatedAt?: number }> =
+			[];
 		const sessionsDir = join(getAppDir(), "sessions");
 
 		if (!existsSync(sessionsDir)) {
@@ -1890,27 +1898,27 @@ export class WebChannel implements Channel {
 			const dirs = readdirSync(sessionsDir);
 			const webSessions = dirs
 				.filter((dir) => dir.startsWith("web_"))
-				.map((dir) => ({ sessionId: dir, path: join(sessionsDir, dir) }))
-				.filter(({ path }) => {
+				.map((dir) => {
+					const path = join(sessionsDir, dir);
 					try {
-						return statSync(path).isDirectory();
+						const stats = statSync(path);
+						if (!stats.isDirectory()) return null;
+						return {
+							sessionId: dir,
+							path,
+							createdAt: stats.birthtime?.getTime(),
+							updatedAt: stats.mtime.getTime(),
+						};
 					} catch {
-						return false;
+						return null;
 					}
 				})
+				.filter((session): session is NonNullable<typeof session> => session !== null)
 				// Sort by modification time, newest first
-				.sort((a, b) => {
-					try {
-						const aMtime = statSync(a.path).mtime.getTime();
-						const bMtime = statSync(b.path).mtime.getTime();
-						return bMtime - aMtime;
-					} catch {
-						return 0;
-					}
-				});
+				.sort((a, b) => b.updatedAt - a.updatedAt);
 
 			// For each session directory, check if it's in memory or read from disk
-			for (const { sessionId, path } of webSessions) {
+			for (const { sessionId, path, createdAt, updatedAt } of webSessions) {
 				const inMemorySession = this.sessions.get(sessionId);
 
 				if (inMemorySession) {
@@ -1942,6 +1950,8 @@ export class WebChannel implements Channel {
 						sessionId,
 						title,
 						messageCount: inMemorySession.messages.length,
+						createdAt,
+						updatedAt,
 					});
 				} else {
 					// For sessions not in memory, read title from disk
@@ -1951,6 +1961,8 @@ export class WebChannel implements Channel {
 						sessionId,
 						title,
 						messageCount: 0, // We don't count messages for sessions not in memory
+						createdAt,
+						updatedAt,
 					});
 				}
 			}

--- a/src/lib/scoped-model-resolver.ts
+++ b/src/lib/scoped-model-resolver.ts
@@ -1,0 +1,69 @@
+const THINKING_LEVEL_SUFFIXES = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
+
+export interface ScopedModelCandidate {
+	provider: string;
+	id: string;
+}
+
+function stripThinkingSuffix(pattern: string): string {
+	const trimmed = pattern.trim();
+	const lastColon = trimmed.lastIndexOf(":");
+	if (lastColon === -1) return trimmed;
+
+	const suffix = trimmed.slice(lastColon + 1).toLowerCase();
+	if (THINKING_LEVEL_SUFFIXES.has(suffix)) {
+		return trimmed.slice(0, lastColon);
+	}
+
+	return trimmed;
+}
+
+function hasGlob(pattern: string): boolean {
+	return pattern.includes("*") || pattern.includes("?");
+}
+
+function toGlobRegex(pattern: string): RegExp {
+	const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+	const regex = `^${escaped.replace(/\*/g, ".*").replace(/\?/g, ".")}$`;
+	return new RegExp(regex, "i");
+}
+
+function matchesPattern(pattern: string, model: ScopedModelCandidate): boolean {
+	const normalized = stripThinkingSuffix(pattern);
+	if (!normalized) return false;
+
+	const fullId = `${model.provider}/${model.id}`;
+
+	if (hasGlob(normalized)) {
+		const regex = toGlobRegex(normalized);
+		return regex.test(fullId) || regex.test(model.id);
+	}
+
+	const slashIndex = normalized.indexOf("/");
+	if (slashIndex !== -1) {
+		const provider = normalized.slice(0, slashIndex);
+		const modelId = normalized.slice(slashIndex + 1);
+		return model.provider.toLowerCase() === provider.toLowerCase() && model.id.toLowerCase() === modelId.toLowerCase();
+	}
+
+	return fullId.toLowerCase() === normalized.toLowerCase() || model.id.toLowerCase() === normalized.toLowerCase();
+}
+
+export function resolveScopedModels<T extends ScopedModelCandidate>(patterns: string[], available: T[]): T[] {
+	const resolved: T[] = [];
+	const seen = new Set<string>();
+
+	for (const pattern of patterns) {
+		for (const model of available) {
+			if (!matchesPattern(pattern, model)) continue;
+
+			const key = `${model.provider}/${model.id}`;
+			if (seen.has(key)) continue;
+
+			seen.add(key);
+			resolved.push(model);
+		}
+	}
+
+	return resolved;
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -22,6 +22,7 @@ import { type AppConfig, getAgentDir, getAppDir, getAuthPath, getWorkspace } fro
 import { createCronExtension } from "./extensions/cron/index.ts";
 import { createHeartbeatExtension } from "./extensions/heartbeat/index.ts";
 import { createWorkspaceJailExtension } from "./extensions/workspace-jail.ts";
+import { resolveScopedModels } from "./lib/scoped-model-resolver.ts";
 
 // ─── Session cache (one session per chat) ──────────────────────────────────────
 
@@ -116,12 +117,10 @@ export async function getOrCreateSession(chatKey: string, config: AppConfig): Pr
 	const enabledModels = session.settingsManager.getEnabledModels();
 	if (enabledModels && enabledModels.length > 0) {
 		const available = await session.modelRegistry.getAvailable();
-		const resolved = [];
-		for (const pattern of enabledModels) {
-			const [provider, modelId] = pattern.split("/", 2);
-			const model = available.find((m) => m.provider === provider && m.id === modelId);
-			if (model) resolved.push({ model, thinkingLevel: session.thinkingLevel });
-		}
+		const resolved = resolveScopedModels(enabledModels, available).map((model) => ({
+			model,
+			thinkingLevel: session.thinkingLevel,
+		}));
 		if (resolved.length > 0) {
 			session.setScopedModels(resolved);
 			console.log(`[session] Applied ${resolved.length} scoped models for session ${chatKey}`);

--- a/web-ui/src/components/nav-sessions.tsx
+++ b/web-ui/src/components/nav-sessions.tsx
@@ -103,7 +103,7 @@ export function NavRecentSessions() {
                 
                 {/* Date */}
                 <span className="text-[11px] text-muted-foreground/50">
-                  {formatSessionDate(session.updatedAt)}
+                  {formatSessionDate(session.updatedAt ?? session.createdAt)}
                 </span>
               </SidebarMenuButton>
               

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -81,7 +81,13 @@ export class ClankieClient {
 	}
 
 	async listSessions(): Promise<{
-		sessions: Array<{ sessionId: string; title?: string; messageCount: number }>;
+		sessions: Array<{
+			sessionId: string;
+			title?: string;
+			messageCount: number;
+			createdAt?: number;
+			updatedAt?: number;
+		}>;
 	}> {
 		const response = await this.sendCommand({ type: "list_sessions" });
 		return response as {
@@ -89,6 +95,8 @@ export class ClankieClient {
 				sessionId: string;
 				title?: string;
 				messageCount: number;
+				createdAt?: number;
+				updatedAt?: number;
 			}>;
 		};
 	}

--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -130,7 +130,8 @@ class ClientManager {
 					sessionId: session.sessionId,
 					title: session.title,
 					messageCount: session.messageCount,
-					createdAt: Date.now(),
+					createdAt: session.createdAt ?? session.updatedAt ?? Date.now(),
+					updatedAt: session.updatedAt,
 				});
 			}
 		} catch (err) {
@@ -176,6 +177,7 @@ class ClientManager {
 				title: undefined,
 				messageCount: 0,
 				createdAt: Date.now(),
+				updatedAt: Date.now(),
 			});
 
 			// Set it as active
@@ -332,6 +334,7 @@ class ClientManager {
 					title,
 					messageCount: state.messageCount,
 					createdAt: Date.now(),
+					updatedAt: Date.now(),
 				});
 			}
 


### PR DESCRIPTION
## Summary\n- fix scoped model resolution to handle provider/model ids with embedded slashes and simple glob patterns\n- apply the same scoped model resolution during session bootstrap and RPC updates\n- return authoritative persisted  after \n- include server-side session timestamps in  and consume them in the web UI store hydration\n- update recent sessions date rendering fallback to \n\n## Validation\n-  ✅\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 248.
Checked 149 files in 76ms. No fixes applied.
Found 188 errors.
Found 79 warnings.
Found 1 info. ❌ (fails due pre-existing repository-wide Biome/format issues unrelated to this PR)\n\nCloses #159