### PR TITLE
Fix session recency timestamps using latest JSONL activity

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -1834,6 +1834,27 @@ export class WebChannel implements Channel {
 
 	// ─── Helpers ───────────────────────────────────────────────────────────────
 
+	private getSessionLatestJsonlMtime(sessionPath: string): number | undefined {
+		try {
+			const files = readdirSync(sessionPath)
+				.filter((f) => f.endsWith(".jsonl"))
+				.map((f) => {
+					const filePath = join(sessionPath, f);
+					try {
+						return statSync(filePath).mtime.getTime();
+					} catch {
+						return undefined;
+					}
+				})
+				.filter((mtime): mtime is number => mtime !== undefined)
+				.sort((a, b) => b - a);
+
+			return files[0];
+		} catch {
+			return undefined;
+		}
+	}
+
 	/**
 	 * Extract title from a session directory by reading the last user message from JSONL files
 	 */
@@ -1903,11 +1924,13 @@ export class WebChannel implements Channel {
 					try {
 						const stats = statSync(path);
 						if (!stats.isDirectory()) return null;
+
+						const latestJsonlMtime = this.getSessionLatestJsonlMtime(path);
 						return {
 							sessionId: dir,
 							path,
 							createdAt: stats.birthtime?.getTime(),
-							updatedAt: stats.mtime.getTime(),
+							updatedAt: latestJsonlMtime ?? stats.mtime.getTime(),
 						};
 					} catch {
 						return null;


### PR DESCRIPTION
## Summary\n- derive session  from the newest  file mtime instead of directory mtime\n- keep fallback to directory mtime when no JSONL files are present\n- preserve existing title derivation logic\n\n## Why\nDirectory mtimes were often identical/stale, causing the sidebar to show the same date for many sessions and hurting recency ordering.\n\n## Validation\n-  ✅\n- The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 248.
Checked 149 files in 77ms. No fixes applied.
Found 188 errors.
Found 79 warnings.
Found 1 info. ❌ (pre-existing repository-wide Biome/format issues unrelated to this change)