### PR TITLE
Fix extension install path handling and add clankie-admin skill

### DIFF
--- a/skills/clankie-admin/SKILL.md
+++ b/skills/clankie-admin/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: clankie-admin
+description: Manage clankie configuration, install/update Pi packages, and create local skills/extensions in the correct clankie directories. Use when asked to install or maintain clankie skills/extensions.
+---
+
+# Clankie Admin
+
+Use this skill when the user asks to install, update, remove, or create skills/extensions for clankie.
+
+## Directory layout (source of truth)
+
+Clankie uses `~/.clankie/` as its global agent directory:
+
+- `~/.clankie/settings.json` → Pi global settings for clankie
+- `~/.clankie/clankie.json` → Clankie app config
+- `~/.clankie/extensions/` → user-scope local extensions
+- `~/.clankie/skills/` → user-scope local skills
+- `~/.clankie/prompts/` → user-scope prompt templates
+- `~/.clankie/themes/` → user-scope themes
+- `~/.clankie/git/` → git-based package installs
+- `~/.clankie/workspace/` → working directory (not the global package location)
+
+## Installation rules
+
+1. Prefer **user scope** installs for clankie-managed packages.
+2. Avoid project-local installs into `~/.clankie/workspace/.pi/` unless the user explicitly asks for project scope.
+3. After install/update/remove, reload the session so newly loaded resources become available.
+
+## Creating a skill
+
+Create skills under:
+
+- `~/.clankie/skills/<skill-name>/SKILL.md`
+
+Requirements:
+
+- Directory name must match frontmatter `name`
+- Include frontmatter with `name` and `description`
+- Keep description specific about when to use the skill
+
+## Creating an extension
+
+Create extensions under:
+
+- `~/.clankie/extensions/<extension-name>/`
+
+Keep extension code and any package metadata there. If the extension ships skills, place them under a `skills/` folder in the extension package and expose them through the package manifest.
+
+## Safety checks
+
+Before changing files, confirm target paths are under `~/.clankie/` for global clankie resources.
+If an install path would resolve to `~/.clankie/workspace/.pi/`, explicitly confirm with the user before proceeding.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,6 +13,7 @@
  * If not set, falls back to pi's default resolution (settings → first available).
  */
 
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
 	AuthStorage,
@@ -85,11 +86,14 @@ export async function createSession(options: SessionOptions = {}): Promise<Creat
 	// agentDir=~/.clankie isolates from ~/.pi/agent/ while supporting full
 	// extension loading (jiti), package management, and settings integration.
 	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const bundledSkillsDir = join(import.meta.dirname, "..", "skills");
+	const additionalSkillPaths = existsSync(bundledSkillsDir) ? [bundledSkillsDir] : [];
 	const loader = new DefaultResourceLoader({
 		cwd,
 		agentDir,
 		settingsManager,
 		extensionFactories,
+		additionalSkillPaths,
 	});
 	await loader.reload();
 

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -22,13 +22,19 @@ import type { WebSocket, WebSocketServer } from "ws";
 import { createNodeWebSocket } from "@hono/node-ws";
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ImageContent, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
-import { type AgentSession, type AgentSessionEvent, AuthStorage } from "@mariozechner/pi-coding-agent";
+import {
+	type AgentSession,
+	type AgentSessionEvent,
+	AuthStorage,
+	DefaultPackageManager,
+	SettingsManager,
+} from "@mariozechner/pi-coding-agent";
 import { Hono } from "hono";
 import { parse as parseCookie, serialize as serializeCookie } from "hono/utils/cookie";
 import type { Context } from "hono";
 import type { WSContext } from "hono/ws";
 import { buildApiKeyProviders } from "../auth/providers.ts";
-import { getAppDir, getAuthPath, loadConfig } from "../config.ts";
+import { getAgentDir, getAppDir, getAuthPath, getWorkspace, loadConfig } from "../config.ts";
 import { reloadSharedHeartbeatRunnerSettings } from "../extensions/heartbeat/index.ts";
 import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
 import { resolveScopedModels } from "../lib/scoped-model-resolver.ts";
@@ -1432,37 +1438,40 @@ export class WebChannel implements Channel {
 
 			case "install_package": {
 				const { source, local } = command;
-				const installCommand = `pi install ${local ? "-l " : ""}${source}`;
+				const config = loadConfig();
+				const cwd = getWorkspace(config);
+				const agentDir = getAgentDir(config);
+				const settingsManager = SettingsManager.create(cwd, agentDir);
+				const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+				const output: string[] = [];
+
+				packageManager.setProgressCallback((event) => {
+					if (event.type === "start" && event.message) {
+						output.push(event.message);
+					}
+					if (event.type === "error" && event.message) {
+						output.push(`Error: ${event.message}`);
+					}
+				});
 
 				try {
-					// Run pi install via bash
-					const result = await session.executeBash(installCommand);
-
-					if (result.exitCode === 0) {
-						// Successful install - reload the session to pick up new extensions/skills
-						await session.reload();
-
-						return {
-							id,
-							type: "response",
-							command: "install_package",
-							success: true,
-							data: {
-								output: result.output,
-								exitCode: result.exitCode,
-							},
-						};
+					await packageManager.install(source, { local: local === true });
+					const added = packageManager.addSourceToSettings(source, { local: local === true });
+					if (!added) {
+						output.push(`Package source already configured: ${source}`);
 					}
 
-					// Non-zero exit code - return as success but with exitCode info
+					// Successful install - reload the session to pick up new extensions/skills
+					await session.reload();
+
 					return {
 						id,
 						type: "response",
 						command: "install_package",
 						success: true,
 						data: {
-							output: result.output,
-							exitCode: result.exitCode,
+							output: output.join("\n") || `Installed ${source}`,
+							exitCode: 0,
 						},
 					};
 				} catch (err) {


### PR DESCRIPTION
## Summary
- replace `install_package` shelling (`pi install ...`) with SDK `DefaultPackageManager` using clankie config (`agentDir` + `workspace`)
- reload session after successful install and keep install progress output for the UI response
- add bundled default skill `skills/clankie-admin/SKILL.md` documenting clankie paths and install conventions
- wire bundled `skills/` directory into `DefaultResourceLoader` via `additionalSkillPaths`

## Why
This avoids relying on external `pi` CLI defaults and keeps package operations aligned with clankie’s own configured directories. It also provides agent guidance for extension/skill management via a built-in skill.

Closes #172

## Validation
- `bun run typecheck` ✅
- `bun run check` ⚠️ fails due to large pre-existing formatting/lint issues unrelated to this PR (web-ui and other files)
