### PR TITLE
Web UI: Move Settings to Sidebar Footer with Dropdown Menu

### DIFF
--- a/web-ui/src/components/__tests__/nav-secondary.test.tsx
+++ b/web-ui/src/components/__tests__/nav-secondary.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as React from 'react'
+import { NavSecondary } from '../nav-secondary'
+import { SidebarProvider } from '@/components/ui/sidebar'
+
+// Mock tanstack router
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    useRouterState: () => ({
+      location: { pathname: '/settings/theme' },
+    }),
+    Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+// A simple wrapper that provides the SidebarProvider
+function renderWithSidebar(ui: React.ReactElement) {
+  return render(
+    <SidebarProvider>
+      {ui}
+    </SidebarProvider>
+  )
+}
+
+describe('NavSecondary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders settings button', () => {
+    renderWithSidebar(<NavSecondary />)
+
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('opens dropdown when settings button is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithSidebar(<NavSecondary />)
+
+    const settingsButton = screen.getByRole('button')
+    await user.click(settingsButton)
+
+    // All settings items should be visible
+    await waitFor(() => {
+      expect(screen.getByText('Appearance')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Connection')).toBeInTheDocument()
+    expect(screen.getByText('Auth')).toBeInTheDocument()
+    expect(screen.getByText('Extensions')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+  })
+
+  it('renders settings links with correct hrefs', async () => {
+    const user = userEvent.setup()
+    renderWithSidebar(<NavSecondary />)
+
+    const settingsButton = screen.getByRole('button')
+    await user.click(settingsButton)
+
+    await waitFor(() => {
+      const appearanceLink = screen.getByText('Appearance').closest('a')
+      expect(appearanceLink).toHaveAttribute('href', '/settings/theme')
+
+      const connectionLink = screen.getByText('Connection').closest('a')
+      expect(connectionLink).toHaveAttribute('href', '/settings/connection')
+
+      const authLink = screen.getByText('Auth').closest('a')
+      expect(authLink).toHaveAttribute('href', '/settings/auth')
+
+      const extensionsLink = screen.getByText('Extensions').closest('a')
+      expect(extensionsLink).toHaveAttribute('href', '/settings/extensions')
+
+      const skillsLink = screen.getByText('Skills').closest('a')
+      expect(skillsLink).toHaveAttribute('href', '/settings/skills')
+    })
+  })
+
+  it('shows active state when in settings route', () => {
+    renderWithSidebar(<NavSecondary />)
+
+    const button = screen.getByRole('button')
+    // The button should have isActive prop applied which sets data-active attribute
+    expect(button).toHaveAttribute('data-active')
+  })
+})

--- a/web-ui/src/components/app-sidebar.tsx
+++ b/web-ui/src/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input'
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -57,8 +58,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       <SidebarContent className="gap-2 px-2 py-2">
         <NavMain />
         <NavRecentSessions />
-        <NavSecondary className="mt-auto" />
       </SidebarContent>
+
+      <SidebarFooter className="px-2 py-2">
+        <NavSecondary />
+      </SidebarFooter>
     </Sidebar>
   )
 }

--- a/web-ui/src/components/nav-secondary.tsx
+++ b/web-ui/src/components/nav-secondary.tsx
@@ -1,6 +1,5 @@
 import { Link, useRouterState } from '@tanstack/react-router'
 import {
-  ChevronDown,
   Globe,
   KeyRound,
   Palette,
@@ -8,22 +7,18 @@ import {
   Settings,
   Sparkles,
 } from 'lucide-react'
-import { useState } from 'react'
-import type * as React from 'react'
+
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
-  SidebarGroup,
-  SidebarGroupContent,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
+  useSidebar,
 } from '@/components/ui/sidebar'
 
 const settingsLinks = [
@@ -34,53 +29,48 @@ const settingsLinks = [
   { to: '/settings/skills', label: 'Skills', icon: Sparkles },
 ]
 
-export function NavSecondary({
-  ...props
-}: React.ComponentPropsWithoutRef<typeof SidebarGroup>) {
+export function NavSecondary() {
   const { location } = useRouterState()
   const currentPath = location.pathname
   const isInSettings = currentPath.startsWith('/settings')
-  const [settingsOpen, setSettingsOpen] = useState(isInSettings)
+  const { isMobile } = useSidebar()
 
   return (
-    <SidebarGroup {...props} className="px-2 py-2">
-      <SidebarGroupContent>
-        <SidebarMenu className="gap-1">
-          <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <SidebarMenuItem>
-              <CollapsibleTrigger asChild>
-                <SidebarMenuButton className="h-10 text-sm text-sidebar-foreground/70 hover:text-sidebar-foreground rounded-xl">
-                  <Settings className="h-4 w-4" />
-                  <span>Settings</span>
-                  <ChevronDown
-                    className={`ml-auto h-4 w-4 transition-transform text-muted-foreground/50 ${settingsOpen ? 'rotate-180' : ''}`}
-                  />
-                </SidebarMenuButton>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <SidebarMenuSub className="gap-1 py-1">
-                  {settingsLinks.map((link) => {
-                    const Icon = link.icon
-                    const isActive = currentPath === link.to
-                    return (
-                      <SidebarMenuSubItem key={link.to}>
-                        <SidebarMenuSubButton
-                          render={<Link to={link.to} />}
-                          isActive={isActive}
-                          className="h-9 text-xs rounded-lg"
-                        >
-                          <Icon className="h-3.5 w-3.5" />
-                          <span>{link.label}</span>
-                        </SidebarMenuSubButton>
-                      </SidebarMenuSubItem>
-                    )
-                  })}
-                </SidebarMenuSub>
-              </CollapsibleContent>
-            </SidebarMenuItem>
-          </Collapsible>
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                isActive={isInSettings}
+                className="h-10 text-sm text-sidebar-foreground/70 hover:text-sidebar-foreground rounded-xl"
+              >
+                <Settings className="h-4 w-4" />
+                <span>Settings</span>
+              </SidebarMenuButton>
+            }
+          />
+          <DropdownMenuContent
+            side={isMobile ? 'bottom' : 'right'}
+            align={isMobile ? 'end' : 'start'}
+            className="w-48"
+          >
+            {settingsLinks.map((link) => {
+              const Icon = link.icon
+              return (
+                <DropdownMenuItem
+                  key={link.to}
+                  render={<Link to={link.to} />}
+                  className="h-9 text-sm"
+                >
+                  <Icon className="h-4 w-4 mr-2" />
+                  <span>{link.label}</span>
+                </DropdownMenuItem>
+              )
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
   )
 }


### PR DESCRIPTION
## Summary
Moves the Settings navigation from the collapsible sidebar content to a dropdown menu in the sidebar footer, as requested.

## Changes
- **app-sidebar.tsx**: Replaced  inside  with  containing 
- **nav-secondary.tsx**: Refactored from  to  with proper mobile-aware placement
- **nav-secondary.test.tsx**: Added new tests for the dropdown behavior

## Visual Changes
- Settings now appears as a button in the sidebar footer (anchored at bottom)
- Clicking opens a dropdown menu instead of expanding inline
- Settings trigger shows active state when on any /settings/* route
- Dropdown opens to the right on desktop, bottom on mobile

## Testing
- All 4 new NavSecondary tests pass
- TypeScript type checking passes

Closes #181