### PR TITLE
feat: deterministic package install flow for extensions/skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"files": [
 		"dist/",
 		"web-ui-dist/",
+		"skills/",
 		"package.json",
 		"README.md"
 	],

--- a/skills/clankie-admin/SKILL.md
+++ b/skills/clankie-admin/SKILL.md
@@ -24,7 +24,11 @@ Clankie uses `~/.clankie/` as its global agent directory:
 
 1. Prefer **user scope** installs for clankie-managed packages.
 2. Avoid project-local installs into `~/.clankie/workspace/.pi/` unless the user explicitly asks for project scope.
-3. After install/update/remove, reload the session so newly loaded resources become available.
+3. Prefer clankie's controlled package flows:
+   - LLM: `manage_packages` tool
+   - UI: Settings → Extensions install panel
+4. Do **not** use raw `pi install/remove/update` commands in bash unless explicitly requested for debugging.
+5. After install/update/remove, reload the session so newly loaded resources become available.
 
 ## Creating a skill
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -28,6 +28,7 @@ import {
 import { type AppConfig, getAgentDir, getAppDir, getAuthPath, getWorkspace, loadConfig } from "./config.ts";
 import { createCronExtension } from "./extensions/cron/index.ts";
 import { createHeartbeatExtension } from "./extensions/heartbeat/index.ts";
+import { createPackageManagerExtension } from "./extensions/package-manager.ts";
 import { createReloadRuntimeExtension } from "./extensions/reload-runtime.ts";
 import { createWorkspaceJailExtension } from "./extensions/workspace-jail.ts";
 import { reloadAllSessions } from "./sessions.ts";
@@ -42,6 +43,7 @@ export function buildExtensionFactories(config: AppConfig, cwd: string): Extensi
 	const extensionFactories: ExtensionFactory[] = [];
 	extensionFactories.push(createCronExtension());
 	extensionFactories.push(createHeartbeatExtension());
+	extensionFactories.push(createPackageManagerExtension(reloadAllSessions));
 	extensionFactories.push(createReloadRuntimeExtension(reloadAllSessions));
 
 	const restrictToWorkspace = config.agent?.restrictToWorkspace ?? true; // default: enabled

--- a/src/extensions/cron/extension.ts
+++ b/src/extensions/cron/extension.ts
@@ -61,12 +61,12 @@ function parseSchedule(params: CronParams): CronSchedule | undefined {
 
 export function createCronExtension() {
 	return function cronExtension(pi: ExtensionAPI) {
-		pi.on("before_agent_start", async () => {
+		pi.on("before_agent_start", async (event) => {
 			const now = new Date();
 			const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 			const local = now.toLocaleString("sv-SE", { timeZone: timezone, hour12: false }).replace(" ", "T");
 			return {
-				systemPrompt: `\n\nYou can manage scheduled tasks with the cron tool.\nCurrent UTC time: ${now.toISOString()}\nCurrent timezone: ${timezone} (local: ${local})`,
+				systemPrompt: `${event.systemPrompt}\n\nYou can manage scheduled tasks with the cron tool.\nCurrent UTC time: ${now.toISOString()}\nCurrent timezone: ${timezone} (local: ${local})`,
 			};
 		});
 

--- a/src/extensions/package-manager.ts
+++ b/src/extensions/package-manager.ts
@@ -1,0 +1,154 @@
+import { StringEnum } from "@mariozechner/pi-ai";
+import {
+	DefaultPackageManager,
+	type ExtensionAPI,
+	type ExtensionFactory,
+	SettingsManager,
+} from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { getAgentDir, getWorkspace, loadConfig } from "../config.ts";
+
+const PackageManagerParamsSchema = Type.Object({
+	action: StringEnum(["install", "remove", "update", "list"] as const),
+	source: Type.Optional(
+		Type.String({ description: "Package source, e.g. npm:@scope/pkg, git:github.com/user/repo, or local path" }),
+	),
+	scope: Type.Optional(StringEnum(["user", "project"] as const)),
+});
+
+type PackageManagerParams = {
+	action: "install" | "remove" | "update" | "list";
+	source?: string;
+	scope?: "user" | "project";
+};
+
+type PackageManagerToolDetails = {
+	action: "install" | "remove" | "update" | "list";
+	scope: "user" | "project";
+	source: string | null;
+	output: string[];
+	globalPackages?: string[];
+	projectPackages?: string[];
+};
+
+function stringifyPackageSource(source: string | { source: string }): string {
+	if (typeof source === "string") return source;
+	return source.source;
+}
+
+export function createPackageManagerExtension(reloadAllSessions: () => Promise<void>): ExtensionFactory {
+	return function packageManagerExtension(pi: ExtensionAPI) {
+		let pendingReload = false;
+
+		pi.on("agent_end", () => {
+			if (!pendingReload) return;
+			pendingReload = false;
+			setTimeout(() => {
+				reloadAllSessions().catch((err) => {
+					console.error("[package-manager] Failed to reload sessions:", err);
+				});
+			}, 0);
+		});
+
+		pi.registerTool({
+			name: "manage_packages",
+			label: "Manage Packages",
+			description:
+				"Install, remove, update, or list clankie packages in the correct clankie directories. Defaults to user scope.",
+			parameters: PackageManagerParamsSchema,
+			async execute(_toolCallId, rawParams) {
+				const params = rawParams as PackageManagerParams;
+				const config = loadConfig();
+				const cwd = getWorkspace(config);
+				const agentDir = getAgentDir(config);
+				const settingsManager = SettingsManager.create(cwd, agentDir);
+				const packageManager = new DefaultPackageManager({ cwd, agentDir, settingsManager });
+				const output: string[] = [];
+
+				packageManager.setProgressCallback((event) => {
+					if (!event.message) return;
+					output.push(event.message);
+				});
+
+				const scope = params.scope ?? "user";
+				const local = scope === "project";
+				const detailsBase: PackageManagerToolDetails = {
+					action: params.action,
+					scope,
+					source: params.source?.trim() ?? null,
+					output,
+				};
+
+				try {
+					switch (params.action) {
+						case "list": {
+							const globalPackages = (settingsManager.getGlobalSettings().packages ?? []).map(stringifyPackageSource);
+							const projectPackages = (settingsManager.getProjectSettings().packages ?? []).map(stringifyPackageSource);
+							const lines = [
+								"Configured package sources:",
+								`- User (${globalPackages.length}): ${globalPackages.length > 0 ? globalPackages.join(", ") : "(none)"}`,
+								`- Project (${projectPackages.length}): ${projectPackages.length > 0 ? projectPackages.join(", ") : "(none)"}`,
+							];
+							return {
+								content: [{ type: "text", text: lines.join("\n") }],
+								details: { ...detailsBase, globalPackages, projectPackages },
+							};
+						}
+						case "install": {
+							if (!params.source?.trim()) {
+								throw new Error("install requires source");
+							}
+							const source = params.source.trim();
+							await packageManager.install(source, { local });
+							packageManager.addSourceToSettings(source, { local });
+							pendingReload = true;
+							const summary =
+								output.join("\n") || `Installed ${source} in ${scope} scope and scheduled runtime reload.`;
+							return {
+								content: [{ type: "text", text: summary }],
+								details: { ...detailsBase, source },
+							};
+						}
+						case "remove": {
+							if (!params.source?.trim()) {
+								throw new Error("remove requires source");
+							}
+							const source = params.source.trim();
+							await packageManager.remove(source, { local });
+							packageManager.removeSourceFromSettings(source, { local });
+							pendingReload = true;
+							const summary =
+								output.join("\n") || `Removed ${source} from ${scope} scope and scheduled runtime reload.`;
+							return {
+								content: [{ type: "text", text: summary }],
+								details: { ...detailsBase, source },
+							};
+						}
+						case "update": {
+							const source = params.source?.trim();
+							await packageManager.update(source && source.length > 0 ? source : undefined);
+							pendingReload = true;
+							const summary =
+								output.join("\n") ||
+								`Updated ${source && source.length > 0 ? source : "all configured packages"} and scheduled runtime reload.`;
+							return {
+								content: [{ type: "text", text: summary }],
+								details: { ...detailsBase, source: source ?? null },
+							};
+						}
+					}
+				} catch (err) {
+					return {
+						content: [
+							{
+								type: "text",
+								text: `Package manager error: ${err instanceof Error ? err.message : String(err)}`,
+							},
+						],
+						details: detailsBase,
+					};
+				}
+			},
+		});
+	};
+}

--- a/src/extensions/workspace-jail.ts
+++ b/src/extensions/workspace-jail.ts
@@ -88,6 +88,15 @@ export function createWorkspaceJailExtension(workspaceDir: string, allowedPaths:
 		 * This is defense-in-depth, not a complete sandbox.
 		 */
 		function scanBashCommand(command: string): { allowed: boolean; reason?: string } {
+			const packageCommandPattern = /(^|\s)(pi\s+(install|remove|update))(\s|$)/;
+			if (packageCommandPattern.test(command)) {
+				return {
+					allowed: false,
+					reason:
+						"Blocked: use the manage_packages tool (or Settings → Extensions install UI) instead of running `pi install/remove/update` in bash.",
+				};
+			}
+
 			// Validate explicit absolute/tilde paths mentioned in command text.
 			const absolutePathPattern = /(?:^|\s)([~/][\w\-./]+)/g;
 			let match: RegExpExecArray | null;
@@ -157,12 +166,12 @@ export function createWorkspaceJailExtension(workspaceDir: string, allowedPaths:
 		});
 
 		// Inject system prompt reminder
-		pi.on("before_agent_start", async () => {
+		pi.on("before_agent_start", async (event) => {
 			const allowedPathsNote = normalizedAllowedPaths.length
 				? `\nAlso allowed: ${normalizedAllowedPaths.join(", ")}`
 				: "";
 			return {
-				systemPrompt: `\n\nIMPORTANT: You are restricted to working within the directory: ${workspaceDir}${allowedPathsNote}
+				systemPrompt: `${event.systemPrompt}\n\nIMPORTANT: You are restricted to working within the directory: ${workspaceDir}${allowedPathsNote}
 Do not access files, run commands, or reference paths outside the allowed directories.`,
 			};
 		});

--- a/web-ui/src/routes/settings/extensions.tsx
+++ b/web-ui/src/routes/settings/extensions.tsx
@@ -41,7 +41,13 @@ import {
 } from '@/lib/extension-utils'
 import { JsonRenderRenderer } from '@/lib/tool-renderers/json-render-renderer'
 import { connectionStore } from '@/stores/connection'
-import { extensionsStore, setExtensions, setLoading } from '@/stores/extensions'
+import {
+  extensionsStore,
+  resetInstallStatus,
+  setExtensions,
+  setInstallStatus,
+  setLoading,
+} from '@/stores/extensions'
 import { sessionsListStore } from '@/stores/sessions-list'
 
 export const Route = createFileRoute('/settings/extensions')({
@@ -88,12 +94,14 @@ function ExtensionsSettingsPage() {
     activeSessionId: state.activeSessionId,
   }))
 
-  const { extensions, extensionErrors, isLoading } = useStore(
+  const { extensions, extensionErrors, isLoading, installStatus } = useStore(
     extensionsStore,
     (state) => state,
   )
 
   const [searchValue, setSearchValue] = useState('')
+  const [packageSource, setPackageSource] = useState('')
+  const [installScope, setInstallScope] = useState<'user' | 'project'>('user')
 
   const isConnected = status === 'connected'
 
@@ -114,6 +122,52 @@ function ExtensionsSettingsPage() {
       setLoading(false)
     }
   }, [activeSessionId])
+
+  const installPackage = useCallback(async () => {
+    const client = clientManager.getClient()
+    if (!client || !activeSessionId) return
+
+    const source = packageSource.trim()
+    if (!source) {
+      setInstallStatus({
+        isInstalling: false,
+        error: 'Package source is required',
+      })
+      return
+    }
+
+    resetInstallStatus()
+    setInstallStatus({
+      isInstalling: true,
+      output: `Installing ${source} (${installScope} scope)...`,
+      exitCode: null,
+      error: undefined,
+    })
+
+    try {
+      const result = await client.installPackage(
+        activeSessionId,
+        source,
+        installScope === 'project',
+      )
+
+      setInstallStatus({
+        isInstalling: false,
+        output: result.output,
+        exitCode: result.exitCode,
+        error: undefined,
+      })
+      setPackageSource('')
+      await loadExtensions()
+    } catch (err) {
+      setInstallStatus({
+        isInstalling: false,
+        error:
+          err instanceof Error ? err.message : 'Failed to install package',
+        exitCode: 1,
+      })
+    }
+  }, [activeSessionId, installScope, loadExtensions, packageSource])
 
   useEffect(() => {
     if (isConnected && activeSessionId) {
@@ -262,8 +316,8 @@ function ExtensionsSettingsPage() {
                       Extension Load Errors
                     </p>
                     <div className="mt-2 space-y-2">
-                      {extensionErrors.map((err, idx) => (
-                        <div key={idx} className="text-xs">
+                      {extensionErrors.map((err) => (
+                        <div key={`${err.path}-${err.error}`} className="text-xs">
                           <p className="font-mono text-muted-foreground">
                             {err.path}
                           </p>
@@ -283,7 +337,7 @@ function ExtensionsSettingsPage() {
                   No extensions loaded.
                 </p>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Ask the AI to install extensions for you.
+                  Install packages below or ask the AI to use manage_packages.
                 </p>
               </div>
             ) : (
@@ -377,21 +431,96 @@ function ExtensionsSettingsPage() {
         </Card>
 
         <Card className="card-depth border-primary/20 bg-primary/5">
-          <CardContent className="pt-6">
+          <CardContent className="pt-6 space-y-4">
             <div className="flex items-start gap-3">
               <div className="p-2 rounded-lg bg-primary/10">
                 <Lightbulb className="h-5 w-5 text-primary" />
               </div>
-              <div className="flex-1">
-                <h3 className="font-medium mb-1">Installing Packages</h3>
-                <p className="text-sm text-muted-foreground">
-                  Ask the AI in chat to install extensions for you.
-                </p>
-                <code className="block mt-2 rounded bg-muted/50 p-2 text-xs font-mono">
-                  install @pi/heartbeat
-                </code>
+              <div className="flex-1 space-y-3">
+                <div>
+                  <h3 className="font-medium mb-1">Install Package</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Use this controlled installer to ensure packages are installed
+                    in clankie paths.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Input
+                    value={packageSource}
+                    onChange={(event) => setPackageSource(event.target.value)}
+                    placeholder="npm:@foo/pi-tools or git:github.com/user/repo"
+                    disabled={installStatus.isInstalling}
+                  />
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={installScope === 'user' ? 'default' : 'outline'}
+                      onClick={() => setInstallScope('user')}
+                      disabled={installStatus.isInstalling}
+                    >
+                      User scope (~/.clankie)
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={
+                        installScope === 'project' ? 'default' : 'outline'
+                      }
+                      onClick={() => setInstallScope('project')}
+                      disabled={installStatus.isInstalling}
+                    >
+                      Project scope (.pi)
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={installPackage}
+                      disabled={installStatus.isInstalling}
+                    >
+                      {installStatus.isInstalling ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Installing...
+                        </>
+                      ) : (
+                        'Install'
+                      )}
+                    </Button>
+                  </div>
+                </div>
               </div>
             </div>
+
+            {(installStatus.output || installStatus.error) && (
+              <div className="rounded-md border bg-background/70 p-3 space-y-2">
+                {installStatus.error && (
+                  <p className="text-xs text-destructive">{installStatus.error}</p>
+                )}
+                {installStatus.output && (
+                  <pre className="text-xs whitespace-pre-wrap font-mono text-muted-foreground">
+                    {installStatus.output}
+                  </pre>
+                )}
+                {installStatus.exitCode !== null && (
+                  <p className="text-xs text-muted-foreground">
+                    Exit code: {installStatus.exitCode}
+                  </p>
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={resetInstallStatus}
+                  disabled={installStatus.isInstalling}
+                >
+                  Clear output
+                </Button>
+              </div>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/web-ui/src/routes/settings/index.tsx
+++ b/web-ui/src/routes/settings/index.tsx
@@ -102,8 +102,9 @@ function SettingsIndexPage() {
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-muted-foreground">
             <p>
-              <strong>Installing packages:</strong> Ask the AI in chat to
-              install packages for you. For example: "install @pi/heartbeat"
+              <strong>Installing packages:</strong> Use Settings → Extensions
+              install panel (recommended), or ask the AI to use
+              <code className="mx-1">manage_packages</code>.
             </p>
             <p>
               <strong>Connection:</strong> Make sure clankie is running and the


### PR DESCRIPTION
## Summary
- add a new `manage_packages` extension tool that installs/removes/updates/lists packages using clankie paths (`~/.clankie` user scope by default)
- wire the new package manager extension into `buildExtensionFactories()`
- defer runtime reload after package mutations so active sessions pick up resources safely after current agent turn
- update workspace jail to block raw `pi install/remove/update` in bash and direct users to `manage_packages` / Settings UI
- fix `before_agent_start` prompt composition in cron and workspace-jail (append to `event.systemPrompt` instead of replacing it)
- add a controlled install panel in Settings → Extensions (source input, user/project scope, install status/output)
- update settings tips and clankie-admin skill guidance to prefer controlled install flows
- include `skills/` in published package files

## Validation
- `bun run typecheck` ✅
- `bun run check` ❌ (fails due pre-existing repo-wide Biome/style diagnostics unrelated to this PR; no new global check baseline introduced)
