### PR TITLE
feat: Web UI Notification System for Background Tasks

### DIFF
--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -38,6 +38,7 @@ import { getAgentDir, getAppDir, getAuthPath, getWorkspace, loadConfig } from ".
 import { reloadSharedHeartbeatRunnerSettings } from "../extensions/heartbeat/index.ts";
 import { HEARTBEAT_EXTENSION_UI_SPEC } from "../extensions/heartbeat/ui-spec.ts";
 import { resolveScopedModels } from "../lib/scoped-model-resolver.ts";
+import { type Notification, getNotifications, markRead, markAllRead, dismissNotification, dismissAll, setBroadcastCallback } from "../notifications.ts";
 import { getOrCreateSession, reloadAllSessions } from "../sessions.ts";
 import type { Channel, MessageHandler } from "./channel.ts";
 
@@ -60,6 +61,12 @@ interface InboundWebMessage {
 	command: RpcCommand;
 }
 
+/** Notification event for real-time delivery */
+interface NotificationEvent {
+	type: "notification";
+	notification: Notification;
+}
+
 /** Extended session events including custom events */
 type ExtendedAgentSessionEvent =
 	| AgentSessionEvent
@@ -68,8 +75,8 @@ type ExtendedAgentSessionEvent =
 
 /** Outbound message to client */
 interface OutboundWebMessage {
-	sessionId: string; // "_auth" for auth events
-	event: ExtendedAgentSessionEvent | RpcResponse | RpcExtensionUIRequest | AuthEvent;
+	sessionId: string; // "_auth" for auth events, "_notifications" for notification events
+	event: ExtendedAgentSessionEvent | RpcResponse | RpcExtensionUIRequest | AuthEvent | NotificationEvent;
 }
 
 /** RPC command types from pi */
@@ -129,7 +136,13 @@ type RpcCommand =
 	| { id?: string; type: "auth_login_cancel"; loginFlowId: string }
 	| { id?: string; type: "auth_logout"; providerId: string }
 	| { id?: string; type: "get_scoped_models" }
-	| { id?: string; type: "set_scoped_models"; models: string[] };  // "provider/modelId" strings
+	| { id?: string; type: "set_scoped_models"; models: string[] }  // "provider/modelId" strings
+	// Notifications
+	| { id?: string; type: "get_notifications" }
+	| { id?: string; type: "mark_notification_read"; notificationId: string }
+	| { id?: string; type: "mark_all_notifications_read" }
+	| { id?: string; type: "dismiss_notification"; notificationId: string }
+	| { id?: string; type: "dismiss_all_notifications" };
 
 /** RPC response types from pi */
 type RpcResponse =
@@ -526,8 +539,14 @@ export class WebChannel implements Channel {
 		}
 	>();
 
+	/** All connected WebSocket clients (for broadcasting) */
+	private allConnections = new Set<WSContext>();
+
 	/** Heartbeat interval for keeping WebSocket connections alive */
 	private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+
+	/** Notification broadcast callback cleanup function */
+	private notificationCleanup: (() => void) | null = null;
 
 	constructor(options: WebChannelOptions) {
 		this.options = options;
@@ -587,8 +606,9 @@ export class WebChannel implements Channel {
 
 				// Return WebSocket handlers
 				return {
-					onOpen: (_evt: Event, _ws: WSContext<WebSocket>) => {
+					onOpen: (_evt: Event, ws: WSContext<WebSocket>) => {
 						console.log("[web] Client connected");
+						this.allConnections.add(ws);
 					},
 					onMessage: async (evt: MessageEvent, ws: WSContext<WebSocket>) => {
 						try {
@@ -616,6 +636,7 @@ export class WebChannel implements Channel {
 					},
 					onClose: (_evt: CloseEvent, ws: WSContext<WebSocket>) => {
 						console.log("[web] Client disconnected");
+						this.allConnections.delete(ws);
 
 						// Remove this connection from all session subscriptions
 						for (const [sessionId, subscribers] of this.sessionSubscriptions.entries()) {
@@ -816,6 +837,28 @@ export class WebChannel implements Channel {
 
 		console.log(`[web] WebSocket server listening on port ${this.options.port}`);
 		console.log(`[web] Open in browser: http://localhost:${this.options.port}?token=${this.options.authToken}`);
+
+		// ─── Notification broadcast setup ─────────────────────────────────────
+
+		// Register callback to broadcast notifications to all connected clients
+		const broadcastToAll = (notification: Notification) => {
+			const message: OutboundWebMessage = {
+				sessionId: "_notifications",
+				event: { type: "notification", notification },
+			};
+			const json = JSON.stringify(message);
+
+			for (const ws of this.allConnections) {
+				try {
+					ws.send(json);
+				} catch (err) {
+					console.error("[web] Failed to broadcast notification:", err);
+				}
+			}
+		};
+
+		setBroadcastCallback(broadcastToAll);
+		this.notificationCleanup = () => setBroadcastCallback(null);
 	}
 
 	async send(_chatId: string, _text: string, _options?: { threadId?: string }): Promise<void> {
@@ -828,6 +871,15 @@ export class WebChannel implements Channel {
 			clearInterval(this.heartbeatInterval);
 			this.heartbeatInterval = null;
 		}
+
+		// Clear notification broadcast callback
+		if (this.notificationCleanup) {
+			this.notificationCleanup();
+			this.notificationCleanup = null;
+		}
+
+		// Clear all connections tracking
+		this.allConnections.clear();
 
 		if (this.wss) {
 			for (const client of this.wss.clients) {
@@ -922,6 +974,67 @@ export class WebChannel implements Channel {
 					command: "list_sessions",
 					success: true,
 					data: { sessions },
+				});
+				return;
+			}
+
+			// Notification commands don't need a sessionId
+			if (command.type === "get_notifications") {
+				const notifications = getNotifications();
+				this.sendResponse(ws, undefined, {
+					id: commandId,
+					type: "response",
+					command: "get_notifications",
+					success: true,
+					data: { notifications },
+				});
+				return;
+			}
+
+			if (command.type === "mark_notification_read") {
+				const notification = markRead(command.notificationId);
+				this.sendResponse(ws, undefined, {
+					id: commandId,
+					type: "response",
+					command: "mark_notification_read",
+					success: true,
+					data: { notification },
+				});
+				return;
+			}
+
+			if (command.type === "mark_all_notifications_read") {
+				const count = markAllRead();
+				this.sendResponse(ws, undefined, {
+					id: commandId,
+					type: "response",
+					command: "mark_all_notifications_read",
+					success: true,
+					data: { count },
+				});
+				return;
+			}
+
+			if (command.type === "dismiss_notification") {
+				const notification = dismissNotification(command.notificationId);
+				this.sendResponse(ws, undefined, {
+					id: commandId,
+					type: "response",
+					command: "dismiss_notification",
+					success: true,
+					data: { notification },
+				});
+				return;
+			}
+
+			if (command.type === "dismiss_all_notifications") {
+				const count = dismissAll();
+				this.sendResponse(ws, undefined, {
+					id: commandId,
+					type: "response",
+					command: "dismiss_all_notifications",
+					success: true,
+					data: { count },
 				});
 				return;
 			}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -13,6 +13,7 @@ import type { Channel, InboundMessage } from "./channels/channel.ts";
 import { WebChannel } from "./channels/web.ts";
 import { getAppDir, getBundledWebUiDir, getConfigPath, getWorkspace, loadConfig } from "./config.ts";
 import { CronScheduler, getCronJobsPath, setCronScheduler } from "./extensions/cron/index.ts";
+import { initNotifications } from "./notifications.ts";
 import {
 	getActiveSessionName,
 	getOrCreateSession,
@@ -336,6 +337,9 @@ export async function startDaemon(): Promise<void> {
 	writePidFile();
 
 	console.log(`[daemon] Starting clankie daemon (pid ${process.pid})...`);
+
+	// Initialize notification system
+	initNotifications();
 
 	// Initial startup
 	await initializeChannels();

--- a/src/extensions/cron/scheduler.ts
+++ b/src/extensions/cron/scheduler.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Cron } from "croner";
 import { createSession } from "../../agent.ts";
+import { createNotification } from "../../notifications.ts";
 import { acquireCronLock, releaseCronLock } from "./lock.ts";
 import { ensureJobsFile, loadJobs, saveJobs } from "./storage.ts";
 import type { CronDeliveryTarget, CronJob, CronListItem, CronSchedule } from "./types.ts";
@@ -216,8 +217,39 @@ export class CronScheduler {
 			this.persist();
 		} catch (err) {
 			job.consecutiveFailures += 1;
+			const errorMessage = err instanceof Error ? err.message : String(err);
+			
+			// Create notification for job failure
+			createNotification({
+				type: "error",
+				source: "cron",
+				title: `Cron job failed: ${job.name}`,
+				message: errorMessage,
+				dedupKey: `cron-fail-${job.jobId}`,
+				metadata: {
+					dedupKey: `cron-fail-${job.jobId}`,
+					jobId: job.jobId,
+					jobName: job.name,
+					consecutiveFailures: job.consecutiveFailures,
+					error: errorMessage,
+				},
+			});
+			
 			if (job.consecutiveFailures >= 5) {
 				job.enabled = false;
+				// Create notification for auto-disabled job
+				createNotification({
+					type: "warning",
+					source: "cron",
+					title: `Cron job disabled: ${job.name}`,
+					message: `Job "${job.name}" was automatically disabled after 5 consecutive failures.`,
+					metadata: {
+						jobId: job.jobId,
+						jobName: job.name,
+						consecutiveFailures: job.consecutiveFailures,
+						autoDisabled: true,
+					},
+				});
 			}
 			this.persist();
 			console.error(`[cron] Job failed (${job.name}):`, err);

--- a/src/extensions/heartbeat/runner.ts
+++ b/src/extensions/heartbeat/runner.ts
@@ -7,6 +7,7 @@ import {
 	SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import { getAgentDir, getAppDir, getAuthPath, loadConfig } from "../../config.ts";
+import { createNotification } from "../../notifications.ts";
 import { createCronExtension } from "../cron/index.ts";
 import { createWorkspaceJailExtension } from "../workspace-jail.ts";
 import { acquireHeartbeatLock, releaseHeartbeatLock } from "./lock.ts";
@@ -252,6 +253,23 @@ export class HeartbeatRunner {
 			this.stats.okCount += 1;
 		} else {
 			this.stats.alertCount += 1;
+			// Create notification for heartbeat alert
+			const message = result.error 
+				? `Error: ${result.error}` 
+				: result.normalizedResponse || "Heartbeat check failed";
+			createNotification({
+				type: result.error ? "error" : "warning",
+				source: "heartbeat",
+				title: "Heartbeat Alert",
+				message,
+				dedupKey: `heartbeat-${this.cwd}`,
+				metadata: {
+					dedupKey: `heartbeat-${this.cwd}`,
+					ok: result.ok,
+					error: result.error,
+					timestamp: result.timestamp,
+				},
+			});
 		}
 	}
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,389 @@
+/**
+ * Notification storage and management system.
+ *
+ * Notifications are persisted to disk (~/.clankie/notifications.json)
+ * and broadcast to connected WebSocket clients in real-time.
+ *
+ * Features:
+ * - Auto-pruning of old notifications (500 entry limit)
+ * - Deduplication (prevents spam from frequent failures)
+ * - Atomic file writes (write to temp, then rename)
+ * - Real-time broadcast callback for WebSocket delivery
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { getAppDir } from "./config.ts";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type NotificationType = "info" | "warning" | "error" | "success";
+export type NotificationSource = "heartbeat" | "cron" | "session" | "system";
+
+export interface Notification {
+	/** Unique identifier (UUID) */
+	id: string;
+	/** Notification severity/type */
+	type: NotificationType;
+	/** Source system that created the notification */
+	source: NotificationSource;
+	/** Short title for display */
+	title: string;
+	/** Full message content */
+	message: string;
+	/** ISO 8601 timestamp */
+	timestamp: string;
+	/** Whether the user has read this notification */
+	read: boolean;
+	/** Whether the user has dismissed this notification */
+	dismissed: boolean;
+	/** Optional linked session ID */
+	sessionId?: string;
+	/** Optional URL to navigate to on click */
+	actionUrl?: string;
+	/** Additional metadata for extensibility */
+	metadata?: Record<string, unknown>;
+}
+
+export interface CreateNotificationInput {
+	type: NotificationType;
+	source: NotificationSource;
+	title: string;
+	message: string;
+	sessionId?: string;
+	actionUrl?: string;
+	metadata?: Record<string, unknown>;
+	/** If provided, will deduplicate against existing unread notifications with same source and dedupKey */
+	dedupKey?: string;
+}
+
+export interface NotificationFilter {
+	/** Include notifications marked as read (default: true) */
+	includeRead?: boolean;
+	/** Include dismissed notifications (default: false) */
+	includeDismissed?: boolean;
+	/** Filter by source */
+	source?: NotificationSource;
+	/** Limit results (default: 100) */
+	limit?: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MAX_NOTIFICATIONS = 500;
+const PRUNE_TARGET = 400;
+const NOTIFICATIONS_FILE = "notifications.json";
+
+// ─── State ───────────────────────────────────────────────────────────────────
+
+let notifications: Notification[] = [];
+let writeQueue: Promise<void> = Promise.resolve();
+let broadcastCallback: ((notification: Notification) => void) | null = null;
+
+// ─── File Operations ─────────────────────────────────────────────────────────
+
+function getNotificationsPath(): string {
+	return join(getAppDir(), NOTIFICATIONS_FILE);
+}
+
+function loadNotifications(): Notification[] {
+	const filePath = getNotificationsPath();
+	if (!existsSync(filePath)) {
+		return [];
+	}
+
+	try {
+		const content = readFileSync(filePath, "utf-8");
+		const parsed = JSON.parse(content);
+		if (Array.isArray(parsed)) {
+			return parsed;
+		}
+	} catch (err) {
+		console.error("[notifications] Failed to load notifications:", err);
+	}
+
+	return [];
+}
+
+function atomicWrite(filePath: string, data: string): void {
+	const tempPath = `${filePath}.tmp`;
+	writeFileSync(tempPath, data, "utf-8");
+	renameSync(tempPath, filePath);
+}
+
+function persistNotifications(): void {
+	const filePath = getNotificationsPath();
+	const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+	
+	// Ensure directory exists
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+
+	atomicWrite(filePath, JSON.stringify(notifications, null, 2));
+}
+
+function queuePersist(): void {
+	writeQueue = writeQueue.then(() => {
+		try {
+			persistNotifications();
+		} catch (err) {
+			console.error("[notifications] Failed to persist:", err);
+		}
+	});
+}
+
+// ─── Pruning ─────────────────────────────────────────────────────────────────
+
+function pruneNotifications(): void {
+	if (notifications.length <= MAX_NOTIFICATIONS) {
+		return;
+	}
+
+	// Sort by timestamp (newest first)
+	const sorted = [...notifications].sort(
+		(a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+	);
+
+	// First pass: remove dismissed notifications
+	const withoutDismissed = sorted.filter((n) => !n.dismissed);
+	let toKeep = withoutDismissed;
+
+	// If still over limit, remove read notifications
+	if (toKeep.length > PRUNE_TARGET) {
+		const unread = toKeep.filter((n) => !n.read);
+		const read = toKeep.filter((n) => n.read);
+		// Keep all unread, then oldest read up to limit
+		const readToKeep = read.slice(0, Math.max(0, PRUNE_TARGET - unread.length));
+		toKeep = [...unread, ...readToKeep];
+	}
+
+	// If still over limit, just take the newest
+	if (toKeep.length > PRUNE_TARGET) {
+		toKeep = toKeep.slice(0, PRUNE_TARGET);
+	}
+
+	notifications = toKeep.sort((a, b) => {
+		// Maintain stable order by timestamp then id
+		const timeDiff = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+		if (timeDiff !== 0) return timeDiff;
+		return a.id.localeCompare(b.id);
+	});
+
+	console.log(`[notifications] Pruned from ${sorted.length} to ${notifications.length} entries`);
+}
+
+// ─── Deduplication ───────────────────────────────────────────────────────────
+
+function findDuplicate(input: CreateNotificationInput): Notification | undefined {
+	if (!input.dedupKey) return undefined;
+
+	// Look for unread notification from same source with matching dedupKey in metadata
+	return notifications.find((n) => {
+		if (n.read || n.dismissed) return false;
+		if (n.source !== input.source) return false;
+		return n.metadata?.dedupKey === input.dedupKey;
+	});
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Initialize the notification store. Call once at startup.
+ */
+export function initNotifications(): void {
+	notifications = loadNotifications();
+	console.log(`[notifications] Loaded ${notifications.length} notifications`);
+}
+
+/**
+ * Set a callback to be called when a new notification is created.
+ * The WebChannel uses this to broadcast to all connected clients.
+ */
+export function setBroadcastCallback(callback: ((notification: Notification) => void) | null): void {
+	broadcastCallback = callback;
+}
+
+/**
+ * Create a new notification.
+ * If dedupKey is provided and matches an existing unread notification,
+ * the existing notification is updated instead of creating a new one.
+ */
+export function createNotification(input: CreateNotificationInput): Notification {
+	// Check for duplicate
+	const duplicate = findDuplicate(input);
+	if (duplicate) {
+		// Update the existing notification with new message and timestamp
+		duplicate.message = input.message;
+		duplicate.timestamp = new Date().toISOString();
+		duplicate.title = input.title;
+		duplicate.type = input.type;
+		duplicate.metadata = { ...duplicate.metadata, ...input.metadata };
+		queuePersist();
+		
+		if (broadcastCallback) {
+			broadcastCallback(duplicate);
+		}
+		
+		return duplicate;
+	}
+
+	const notification: Notification = {
+		id: randomUUID(),
+		type: input.type,
+		source: input.source,
+		title: input.title,
+		message: input.message,
+		timestamp: new Date().toISOString(),
+		read: false,
+		dismissed: false,
+		sessionId: input.sessionId,
+		actionUrl: input.actionUrl,
+		metadata: input.metadata,
+	};
+
+	notifications.push(notification);
+	pruneNotifications();
+	queuePersist();
+
+	if (broadcastCallback) {
+		broadcastCallback(notification);
+	}
+
+	return notification;
+}
+
+/**
+ * Get notifications matching the filter criteria.
+ */
+export function getNotifications(filter: NotificationFilter = {}): Notification[] {
+	const {
+		includeRead = true,
+		includeDismissed = false,
+		source,
+		limit = 100,
+	} = filter;
+
+	let result = notifications;
+
+	if (!includeDismissed) {
+		result = result.filter((n) => !n.dismissed);
+	}
+
+	if (!includeRead) {
+		result = result.filter((n) => !n.read);
+	}
+
+	if (source) {
+		result = result.filter((n) => n.source === source);
+	}
+
+	// Sort by timestamp descending
+	result = result.sort(
+		(a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+	);
+
+	return result.slice(0, limit);
+}
+
+/**
+ * Get a single notification by ID.
+ */
+export function getNotification(id: string): Notification | undefined {
+	return notifications.find((n) => n.id === id);
+}
+
+/**
+ * Mark a notification as read.
+ */
+export function markRead(id: string): Notification | undefined {
+	const notification = notifications.find((n) => n.id === id);
+	if (notification && !notification.read) {
+		notification.read = true;
+		queuePersist();
+	}
+	return notification;
+}
+
+/**
+ * Mark all notifications as read.
+ */
+export function markAllRead(): number {
+	let count = 0;
+	for (const notification of notifications) {
+		if (!notification.read && !notification.dismissed) {
+			notification.read = true;
+			count++;
+		}
+	}
+	if (count > 0) {
+		queuePersist();
+	}
+	return count;
+}
+
+/**
+ * Dismiss a notification (soft delete - keeps in storage but hidden from UI).
+ */
+export function dismissNotification(id: string): Notification | undefined {
+	const notification = notifications.find((n) => n.id === id);
+	if (notification && !notification.dismissed) {
+		notification.dismissed = true;
+		queuePersist();
+	}
+	return notification;
+}
+
+/**
+ * Dismiss all notifications.
+ */
+export function dismissAll(): number {
+	let count = 0;
+	for (const notification of notifications) {
+		if (!notification.dismissed) {
+			notification.dismissed = true;
+			count++;
+		}
+	}
+	if (count > 0) {
+		queuePersist();
+	}
+	return count;
+}
+
+/**
+ * Get count of unread notifications.
+ */
+export function getUnreadCount(): number {
+	return notifications.filter((n) => !n.read && !n.dismissed).length;
+}
+
+/**
+ * Get count of all non-dismissed notifications.
+ */
+export function getActiveCount(): number {
+	return notifications.filter((n) => !n.dismissed).length;
+}
+
+/**
+ * Permanently delete old dismissed notifications (for manual cleanup).
+ */
+export function cleanupOldDismissed(olderThanDays: number): number {
+	const cutoff = new Date();
+	cutoff.setDate(cutoff.getDate() - olderThanDays);
+	const cutoffTime = cutoff.getTime();
+
+	const beforeCount = notifications.length;
+	notifications = notifications.filter((n) => {
+		if (!n.dismissed) return true;
+		const notificationTime = new Date(n.timestamp).getTime();
+		return notificationTime > cutoffTime;
+	});
+
+	const deleted = beforeCount - notifications.length;
+	if (deleted > 0) {
+		queuePersist();
+	}
+	return deleted;
+}

--- a/web-ui/src/components/nav-secondary.tsx
+++ b/web-ui/src/components/nav-secondary.tsx
@@ -1,6 +1,8 @@
 import { Link, useRouterState } from '@tanstack/react-router'
+import { useStore } from '@tanstack/react-store'
 import { useState } from 'react'
 import {
+  Bell,
   Filter,
   Globe,
   KeyRound,
@@ -22,6 +24,10 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '@/components/ui/sidebar'
+import {
+  getUnreadCount,
+  notificationsStore,
+} from '@/stores/notifications'
 
 const settingsLinks = [
   { to: '/settings/theme', label: 'Appearance', icon: Palette },
@@ -36,8 +42,11 @@ export function NavSecondary() {
   const { location } = useRouterState()
   const currentPath = location.pathname
   const isInSettings = currentPath.startsWith('/settings')
+  const isInNotifications = currentPath === '/notifications'
   const { isMobile, setOpenMobile } = useSidebar()
   const [open, setOpen] = useState(false)
+
+  const unreadCount = useStore(notificationsStore, getUnreadCount)
 
   const handleNavigate = () => {
     setOpen(false)
@@ -48,6 +57,33 @@ export function NavSecondary() {
 
   return (
     <SidebarMenu>
+      {/* Notifications */}
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          asChild
+          isActive={isInNotifications}
+          className="h-10 text-sm text-sidebar-foreground/70 hover:text-sidebar-foreground rounded-xl"
+        >
+          <Link to="/notifications" onClick={handleNavigate}>
+            <div className="relative">
+              <Bell className="h-4 w-4" />
+              {unreadCount > 0 && (
+                <span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+                </span>
+              )}
+            </div>
+            <span>Notifications</span>
+            {unreadCount > 0 && (
+              <span className="ml-auto text-xs font-medium text-primary">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+
       <SidebarMenuItem>
         <DropdownMenu open={open} onOpenChange={setOpen}>
           <DropdownMenuTrigger

--- a/web-ui/src/lib/clankie-client.ts
+++ b/web-ui/src/lib/clankie-client.ts
@@ -6,6 +6,7 @@
 import { WebSocketClient } from './ws-client'
 import type {
   AgentSessionEvent,
+  AppNotification,
   AuthEvent,
   AuthProvider,
   ExtensionError,
@@ -32,6 +33,7 @@ export interface ClankieClientOptions {
   onEvent: (sessionId: string, event: AgentSessionEvent | RpcResponse) => void
   onAuthEvent: (event: AuthEvent) => void
   onExtensionUIRequest: (event: ExtensionUIRequest) => void
+  onNotification?: (notification: AppNotification) => void
   onStateChange: (state: ConnectionState, error?: string) => void
 }
 
@@ -402,6 +404,35 @@ export class ClankieClient {
     await this.sendCommand({ type: 'reload' }, sessionId)
   }
 
+  // ─── Notifications ─────────────────────────────────────────────────────────
+
+  async getNotifications(): Promise<{ notifications: Array<AppNotification> }> {
+    const response = await this.sendCommand({ type: 'get_notifications' })
+    return response as { notifications: Array<AppNotification> }
+  }
+
+  async markNotificationRead(notificationId: string): Promise<void> {
+    await this.sendCommand({
+      type: 'mark_notification_read',
+      notificationId,
+    })
+  }
+
+  async markAllNotificationsRead(): Promise<void> {
+    await this.sendCommand({ type: 'mark_all_notifications_read' })
+  }
+
+  async dismissNotification(notificationId: string): Promise<void> {
+    await this.sendCommand({
+      type: 'dismiss_notification',
+      notificationId,
+    })
+  }
+
+  async dismissAllNotifications(): Promise<void> {
+    await this.sendCommand({ type: 'dismiss_all_notifications' })
+  }
+
   // ─── Internal ──────────────────────────────────────────────────────────────
 
   private handleMessage(message: OutboundWebMessage | RpcResponse): void {
@@ -441,10 +472,22 @@ export class ClankieClient {
         }
       }
 
+      // Check if it's a notification event (sessionId === "_notifications")
+      if (sessionId === '_notifications') {
+        const notificationEvent = event as unknown as { type: 'notification'; notification: AppNotification }
+        if (notificationEvent.type === 'notification') {
+          this.options.onNotification?.(notificationEvent.notification)
+          return
+        }
+      }
+
       // Check if it's an auth event (sessionId === "_auth")
-      if (sessionId === '_auth' && event.type === 'auth_event') {
-        this.options.onAuthEvent(event)
-        return
+      if (sessionId === '_auth') {
+        const authEvent = event as AuthEvent
+        if (authEvent.type === 'auth_event') {
+          this.options.onAuthEvent(authEvent)
+          return
+        }
       }
 
       if (event.type === 'extension_ui_request') {

--- a/web-ui/src/lib/client-manager.ts
+++ b/web-ui/src/lib/client-manager.ts
@@ -3,7 +3,11 @@
  */
 
 import { ClankieClient } from './clankie-client'
-import { handleAuthEvent, handleSessionEvent } from './event-handlers'
+import {
+  handleAuthEvent,
+  handleNotification,
+  handleSessionEvent,
+} from './event-handlers'
 import type { ExtensionUIResponse } from './types'
 import {
   connectionStore,
@@ -19,6 +23,11 @@ import {
   handleExtensionUIRequest,
   resetExtensionUI,
 } from '@/stores/extension-ui'
+import {
+  resetNotifications,
+  setNotifications,
+  setNotificationsLoading,
+} from '@/stores/notifications'
 import {
   resetSession,
   setAvailableModels,
@@ -69,11 +78,13 @@ class ClientManager {
       },
       onAuthEvent: (event) => handleAuthEvent(event),
       onExtensionUIRequest: (event) => handleExtensionUIRequest(event),
+      onNotification: (notification) => handleNotification(notification),
       onStateChange: (state, error) => {
         updateConnectionStatus(state, error)
         // Restore or create session when connection is established
         if (state === 'connected') {
           this.restoreOrCreateSession()
+          this.loadNotifications()
         }
       },
     })
@@ -94,6 +105,7 @@ class ClientManager {
     clearToolExecutions()
     resetExtensionUI()
     resetScopedModels()
+    resetNotifications()
     // Note: We keep the session ID in localStorage so it can be restored on reconnect
   }
 
@@ -169,6 +181,25 @@ class ClientManager {
       }
     } catch (err) {
       console.error('[client-manager] Failed to load sessions:', err)
+    }
+  }
+
+  private async loadNotifications(): Promise<void> {
+    if (!this.client) {
+      console.error('[client-manager] Cannot load notifications: not connected')
+      return
+    }
+
+    try {
+      setNotificationsLoading(true)
+      const { notifications } = await this.client.getNotifications()
+      console.log(
+        `[client-manager] Loaded ${notifications.length} notifications from server`,
+      )
+      setNotifications(notifications)
+    } catch (err) {
+      console.error('[client-manager] Failed to load notifications:', err)
+      setNotificationsLoading(false)
     }
   }
 

--- a/web-ui/src/lib/event-handlers.ts
+++ b/web-ui/src/lib/event-handlers.ts
@@ -3,7 +3,9 @@
  * Extracted from ClientManager for testability.
  */
 
-import type { AgentSessionEvent, AuthEvent, RpcResponse } from '@/lib/types'
+import { toast } from 'sonner'
+import type { AgentSessionEvent, AppNotification, AuthEvent, RpcResponse } from '@/lib/types'
+import { addNotification } from '@/stores/notifications'
 import { updateLoginFlow } from '@/stores/auth'
 import {
   finishToolExecution,
@@ -263,4 +265,33 @@ export function handleSessionEvent(
 export function handleAuthEvent(event: AuthEvent): void {
   console.log('[event-handlers] Auth event:', event)
   updateLoginFlow(event)
+}
+
+/**
+ * Handle notification events from the WebSocket.
+ * Adds the notification to the store and triggers a toast.
+ */
+export function handleNotification(notification: AppNotification): void {
+  console.log('[event-handlers] Notification:', notification)
+  addNotification(notification)
+
+  // Trigger toast notification
+  const toastFn = {
+    info: toast.info,
+    warning: toast.warning,
+    error: toast.error,
+    success: toast.success,
+  }[notification.type]
+
+  toastFn(notification.title, {
+    description: notification.message,
+    action: notification.actionUrl
+      ? {
+          label: 'View',
+          onClick: () => {
+            window.location.href = notification.actionUrl!
+          },
+        }
+      : undefined,
+  })
 }

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -108,6 +108,12 @@ export type RpcCommand =
   | { id?: string; type: 'auth_logout'; providerId: string }
   | { id?: string; type: 'get_scoped_models' }
   | { id?: string; type: 'set_scoped_models'; models: Array<string> }
+  // Notifications
+  | { id?: string; type: 'get_notifications' }
+  | { id?: string; type: 'mark_notification_read'; notificationId: string }
+  | { id?: string; type: 'mark_all_notifications_read' }
+  | { id?: string; type: 'dismiss_notification'; notificationId: string }
+  | { id?: string; type: 'dismiss_all_notifications' }
 
 // ─── RPC Responses (Server → Client) ──────────────────────────────────────────
 
@@ -272,6 +278,30 @@ export type AgentSessionEvent =
     }
   // Error
   | { type: 'error'; error: string }
+
+// ─── Notifications ───────────────────────────────────────────────────────────
+
+export type NotificationType = 'info' | 'warning' | 'error' | 'success'
+export type NotificationSource = 'heartbeat' | 'cron' | 'session' | 'system'
+
+export interface AppNotification {
+  id: string
+  type: NotificationType
+  source: NotificationSource
+  title: string
+  message: string
+  timestamp: string
+  read: boolean
+  dismissed: boolean
+  sessionId?: string
+  actionUrl?: string
+  metadata?: Record<string, unknown>
+}
+
+export type NotificationEvent = {
+  type: 'notification'
+  notification: AppNotification
+}
 
 export interface SessionState {
   model: ModelInfo

--- a/web-ui/src/routeTree.gen.ts
+++ b/web-ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as NotificationsRouteImport } from './routes/notifications'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as SettingsThemeRouteImport } from './routes/settings/theme'
@@ -19,6 +20,11 @@ import { Route as SettingsConnectionRouteImport } from './routes/settings/connec
 import { Route as SettingsAuthRouteImport } from './routes/settings/auth'
 import { Route as SessionsSessionIdRouteImport } from './routes/sessions.$sessionId'
 
+const NotificationsRoute = NotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -67,6 +73,7 @@ const SessionsSessionIdRoute = SessionsSessionIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/notifications': typeof NotificationsRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
   '/settings/auth': typeof SettingsAuthRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -78,6 +85,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/notifications': typeof NotificationsRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
   '/settings/auth': typeof SettingsAuthRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -90,6 +98,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/notifications': typeof NotificationsRoute
   '/sessions/$sessionId': typeof SessionsSessionIdRoute
   '/settings/auth': typeof SettingsAuthRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -103,6 +112,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/notifications'
     | '/sessions/$sessionId'
     | '/settings/auth'
     | '/settings/connection'
@@ -114,6 +124,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/notifications'
     | '/sessions/$sessionId'
     | '/settings/auth'
     | '/settings/connection'
@@ -125,6 +136,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/notifications'
     | '/sessions/$sessionId'
     | '/settings/auth'
     | '/settings/connection'
@@ -137,6 +149,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  NotificationsRoute: typeof NotificationsRoute
   SessionsSessionIdRoute: typeof SessionsSessionIdRoute
   SettingsAuthRoute: typeof SettingsAuthRoute
   SettingsConnectionRoute: typeof SettingsConnectionRoute
@@ -149,6 +162,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/notifications': {
+      id: '/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof NotificationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -217,6 +237,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  NotificationsRoute: NotificationsRoute,
   SessionsSessionIdRoute: SessionsSessionIdRoute,
   SettingsAuthRoute: SettingsAuthRoute,
   SettingsConnectionRoute: SettingsConnectionRoute,

--- a/web-ui/src/routes/notifications.tsx
+++ b/web-ui/src/routes/notifications.tsx
@@ -1,0 +1,342 @@
+import { Link } from '@tanstack/react-router'
+import { useStore } from '@tanstack/react-store'
+import {
+  AlertCircle,
+  AlertTriangle,
+  ArrowLeft,
+  Bell,
+  Check,
+  CheckCheck,
+  Clock,
+  Info,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { clientManager } from '@/lib/client-manager'
+import { cn } from '@/lib/utils'
+import {
+  dismissAllNotifications,
+  dismissNotification,
+  getActiveNotifications,
+  getNotificationsByDate,
+  markAllNotificationsRead,
+  markNotificationRead,
+  notificationsStore,
+} from '@/stores/notifications'
+
+export const Route = createFileRoute('/notifications')({
+  component: NotificationsPage,
+})
+
+function NotificationsPage() {
+  const { notifications, isLoading } = useStore(
+    notificationsStore,
+    (state) => ({
+      notifications: getActiveNotifications(state),
+      isLoading: state.isLoading,
+    }),
+  )
+
+  const [processingIds, setProcessingIds] = useState<Set<string>>(new Set())
+
+  const handleMarkRead = async (id: string) => {
+    setProcessingIds((prev) => new Set(prev).add(id))
+    try {
+      await clientManager.getClient()?.markNotificationRead(id)
+      markNotificationRead(id)
+    } finally {
+      setProcessingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
+
+  const handleMarkAllRead = async () => {
+    try {
+      await clientManager.getClient()?.markAllNotificationsRead()
+      markAllNotificationsRead()
+    } catch (err) {
+      console.error('Failed to mark all as read:', err)
+    }
+  }
+
+  const handleDismiss = async (id: string) => {
+    setProcessingIds((prev) => new Set(prev).add(id))
+    try {
+      await clientManager.getClient()?.dismissNotification(id)
+      dismissNotification(id)
+    } finally {
+      setProcessingIds((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
+
+  const handleDismissAll = async () => {
+    try {
+      await clientManager.getClient()?.dismissAllNotifications()
+      dismissAllNotifications()
+    } catch (err) {
+      console.error('Failed to dismiss all:', err)
+    }
+  }
+
+  const groupedNotifications = getNotificationsByDate(notifications)
+
+  return (
+    <div className="flex h-full flex-col chat-background">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b bg-card/50 backdrop-blur-sm px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Link to="/">
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-lg font-semibold">Notifications</h1>
+            <p className="text-sm text-muted-foreground">
+              {notifications.length} notification{notifications.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+        </div>
+
+        {notifications.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleMarkAllRead}
+              className="h-8"
+            >
+              <CheckCheck className="h-4 w-4 mr-1.5" />
+              Mark all read
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDismissAll}
+              className="h-8 text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4 mr-1.5" />
+              Clear all
+            </Button>
+          </div>
+        )}
+      </header>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-3xl mx-auto p-4 space-y-6">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Clock className="h-4 w-4 animate-spin" />
+                <span>Loading notifications...</span>
+              </div>
+            </div>
+          ) : notifications.length === 0 ? (
+            <EmptyState />
+          ) : (
+            groupedNotifications.map((group) => (
+              <div key={group.date} className="space-y-3">
+                <h2 className="text-sm font-medium text-muted-foreground px-1">
+                  {group.date}
+                </h2>
+                <div className="space-y-2">
+                  {group.notifications.map((notification) => (
+                    <NotificationCard
+                      key={notification.id}
+                      notification={notification}
+                      isProcessing={processingIds.has(notification.id)}
+                      onMarkRead={() => handleMarkRead(notification.id)}
+                      onDismiss={() => handleDismiss(notification.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface NotificationCardProps {
+  notification: ReturnType<typeof getActiveNotifications>[number]
+  isProcessing: boolean
+  onMarkRead: () => void
+  onDismiss: () => void
+}
+
+function NotificationCard({
+  notification,
+  isProcessing,
+  onMarkRead,
+  onDismiss,
+}: NotificationCardProps) {
+  const timeAgo = formatTimeAgo(notification.timestamp)
+
+  const Icon = {
+    info: Info,
+    warning: AlertTriangle,
+    error: AlertCircle,
+    success: Check,
+  }[notification.type]
+
+  const iconColor = {
+    info: 'text-blue-500',
+    warning: 'text-amber-500',
+    error: 'text-red-500',
+    success: 'text-green-500',
+  }[notification.type]
+
+  const bgColor = {
+    info: 'bg-blue-500/10',
+    warning: 'bg-amber-500/10',
+    error: 'bg-red-500/10',
+    success: 'bg-green-500/10',
+  }[notification.type]
+
+  const CardWrapper = notification.actionUrl ? Link : 'div'
+  const wrapperProps = notification.actionUrl
+    ? { to: notification.actionUrl }
+    : {}
+
+  return (
+    <Card
+      className={cn(
+        'relative transition-opacity',
+        isProcessing && 'opacity-50',
+        !notification.read && 'border-l-4 border-l-primary',
+        notification.actionUrl && 'cursor-pointer hover:bg-muted/50',
+      )}
+    >
+      <CardWrapper {...wrapperProps}>
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            {/* Icon */}
+            <div
+              className={cn(
+                'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg',
+                bgColor,
+              )}
+            >
+              <Icon className={cn('h-5 w-5', iconColor)} />
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <h3 className="font-medium text-sm">{notification.title}</h3>
+                  <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+                    {notification.message}
+                  </p>
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center gap-1 shrink-0">
+                  {!notification.read && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={(e) => {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        onMarkRead()
+                      }}
+                      disabled={isProcessing}
+                      title="Mark as read"
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      onDismiss()
+                    }}
+                    disabled={isProcessing}
+                    title="Dismiss"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="flex items-center gap-2 mt-2">
+                <span className="text-xs text-muted-foreground">{timeAgo}</span>
+                <span className="text-xs text-muted-foreground">•</span>
+                <span className="text-xs text-muted-foreground capitalize">
+                  {notification.source}
+                </span>
+                {notification.sessionId && (
+                  <>
+                    <span className="text-xs text-muted-foreground">•</span>
+                    <span className="text-xs font-mono text-muted-foreground">
+                      {notification.sessionId.slice(0, 8)}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </CardWrapper>
+    </Card>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
+        <Bell className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h3 className="text-lg font-medium">No notifications</h3>
+      <p className="text-sm text-muted-foreground max-w-xs mt-1">
+        You're all caught up! Notifications from heartbeat checks, cron jobs,
+        and other events will appear here.
+      </p>
+    </div>
+  )
+}
+
+function formatTimeAgo(timestamp: string): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSecs = Math.floor(diffMs / 1000)
+  const diffMins = Math.floor(diffSecs / 60)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffSecs < 60) return 'just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+// Required import for createFileRoute
+import { createFileRoute } from '@tanstack/react-router'

--- a/web-ui/src/stores/notifications.ts
+++ b/web-ui/src/stores/notifications.ts
@@ -1,0 +1,167 @@
+/**
+ * Notifications store — manages app notification state.
+ *
+ * Notifications are persisted server-side and delivered in real-time
+ * via WebSocket. This store manages the local cache and UI state.
+ */
+
+import { Store } from '@tanstack/store'
+import type { AppNotification } from '@/lib/types'
+
+export interface NotificationsStore {
+  notifications: Array<AppNotification>
+  isLoading: boolean
+  error?: string
+}
+
+const INITIAL_STATE: NotificationsStore = {
+  notifications: [],
+  isLoading: false,
+}
+
+export const notificationsStore = new Store<NotificationsStore>(INITIAL_STATE)
+
+// ─── Actions ─────────────────────────────────────────────────────────────────
+
+/**
+ * Set the full notifications list (used for initial load)
+ */
+export function setNotifications(notifications: Array<AppNotification>): void {
+  notificationsStore.setState(() => ({
+    notifications,
+    isLoading: false,
+  }))
+}
+
+/**
+ * Add a single notification (used for real-time pushes)
+ */
+export function addNotification(notification: AppNotification): void {
+  notificationsStore.setState((state) => {
+    // Check for duplicate by id
+    if (state.notifications.some((n) => n.id === notification.id)) {
+      return state
+    }
+    return {
+      ...state,
+      notifications: [notification, ...state.notifications],
+    }
+  })
+}
+
+/**
+ * Mark a notification as read
+ */
+export function markNotificationRead(id: string): void {
+  notificationsStore.setState((state) => ({
+    ...state,
+    notifications: state.notifications.map((n) =>
+      n.id === id ? { ...n, read: true } : n,
+    ),
+  }))
+}
+
+/**
+ * Mark all notifications as read
+ */
+export function markAllNotificationsRead(): void {
+  notificationsStore.setState((state) => ({
+    ...state,
+    notifications: state.notifications.map((n) => ({ ...n, read: true })),
+  }))
+}
+
+/**
+ * Dismiss a notification (soft delete)
+ */
+export function dismissNotification(id: string): void {
+  notificationsStore.setState((state) => ({
+    ...state,
+    notifications: state.notifications.filter((n) => n.id !== id),
+  }))
+}
+
+/**
+ * Dismiss all notifications
+ */
+export function dismissAllNotifications(): void {
+  notificationsStore.setState((state) => ({
+    ...state,
+    notifications: [],
+  }))
+}
+
+/**
+ * Set loading state
+ */
+export function setNotificationsLoading(isLoading: boolean): void {
+  notificationsStore.setState((state) => ({ ...state, isLoading }))
+}
+
+/**
+ * Set error state
+ */
+export function setNotificationsError(error: string | undefined): void {
+  notificationsStore.setState((state) => ({ ...state, error }))
+}
+
+/**
+ * Reset store (e.g., on logout)
+ */
+export function resetNotifications(): void {
+  notificationsStore.setState(() => INITIAL_STATE)
+}
+
+// ─── Selectors ───────────────────────────────────────────────────────────────
+
+/**
+ * Get count of unread notifications
+ */
+export function getUnreadCount(state: NotificationsStore): number {
+  return state.notifications.filter((n) => !n.read && !n.dismissed).length
+}
+
+/**
+ * Get non-dismissed notifications sorted by timestamp (newest first)
+ */
+export function getActiveNotifications(
+  state: NotificationsStore,
+): Array<AppNotification> {
+  return state.notifications
+    .filter((n) => !n.dismissed)
+    .sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )
+}
+
+/**
+ * Get notifications grouped by date
+ */
+export function getNotificationsByDate(
+  notifications: Array<AppNotification>,
+): Array<{ date: string; notifications: Array<AppNotification> }> {
+  const groups = new Map<string, Array<AppNotification>>()
+
+  for (const notification of notifications) {
+    const date = new Date(notification.timestamp).toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+
+    if (!groups.has(date)) {
+      groups.set(date, [])
+    }
+    groups.get(date)!.push(notification)
+  }
+
+  return Array.from(groups.entries())
+    .map(([date, notifications]) => ({ date, notifications }))
+    .sort(
+      (a, b) =>
+        new Date(b.notifications[0].timestamp).getTime() -
+        new Date(a.notifications[0].timestamp).getTime(),
+    )
+}


### PR DESCRIPTION
## Summary

Implements a full notification system to alert users when background tasks complete or require attention.

## Problem Solved

Previously, background tasks (heartbeat checks, cron jobs) had no way to notify the user through the web UI:
- Heartbeat alerts were silently persisted to disk JSON files
- Cron job results were only delivered via `channel.send()` if the user was connected
- The existing extension UI notification system was ephemeral (auto-dismiss after 3s)

## Solution

### Backend (`src/notifications.ts`)
- File-based persistence (`~/.clankie/notifications.json`) with auto-pruning (500 entry limit)
- Deduplication logic to prevent notification spam from frequent failures
- Atomic file writes (write to temp, then rename)
- Heartbeat runner creates notifications on alerts
- Cron scheduler creates notifications on failures and auto-disable events
- WebSocket broadcast to all connected clients via `_notifications` channel
- 5 new RPC commands: `get_notifications`, `mark_notification_read`, `mark_all_notifications_read`, `dismiss_notification`, `dismiss_all_notifications`

### Frontend
- **Store**: New notifications store with unread count tracking
- **Toast**: Real-time sonner toasts when notifications arrive
- **Sidebar**: Notification bell with unread count badge and pulsing indicator
- **Page**: `/notifications` route with grouped list, mark read/dismiss actions
- **Integration**: Auto-load on connect, reset on disconnect

## Files Changed
- `src/notifications.ts` (new)
- `src/channels/web.ts` (WebSocket integration)
- `src/daemon.ts` (initialize notifications)
- `src/extensions/heartbeat/runner.ts` (create notifications)
- `src/extensions/cron/scheduler.ts` (create notifications)
- `web-ui/src/lib/types.ts` (types)
- `web-ui/src/lib/clankie-client.ts` (RPC methods)
- `web-ui/src/lib/event-handlers.ts` (handle events)
- `web-ui/src/lib/client-manager.ts` (load on connect)
- `web-ui/src/stores/notifications.ts` (new)
- `web-ui/src/components/nav-secondary.tsx` (bell icon)
- `web-ui/src/routes/notifications.tsx` (new)

## Testing
- [x] TypeScript typecheck passes
- [x] Frontend build succeeds
- [ ] Manual testing of heartbeat alert → notification flow
- [ ] Manual testing of cron failure → notification flow
- [ ] Verify notifications persist across page refresh

## Screenshots

### Notification Bell in Sidebar
- Shows unread count badge when notifications exist
- Pulsing indicator for unread notifications

### Notifications Page
- Groups notifications by date
- Color-coded icons by type (info/warning/error/success)
- Mark read / dismiss actions
- "Mark all read" and "Clear all" bulk actions

### Toast Notifications
- Real-time toasts when new notifications arrive
- Action button to navigate if actionUrl is present

Closes #192